### PR TITLE
fix: write_file 改为追加模式，不覆盖已有文件

### DIFF
--- a/src/tools/write-file.ts
+++ b/src/tools/write-file.ts
@@ -2,7 +2,7 @@
  * 文件写入工具
  * 将内容写入指定路径的文件
  */
-import { writeFileSync, mkdirSync } from 'fs';
+import { writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { Type, type Static } from '@sinclair/typebox';
 
@@ -21,6 +21,7 @@ type WriteFileParams = Static<typeof WriteFileParamsSchema>;
  */
 export interface WriteFileDetails {
   path: string;
+  created: boolean;  // true: 新创建, false: 追加到已有文件
 }
 
 /**
@@ -29,7 +30,7 @@ export interface WriteFileDetails {
 export const writeFileTool = {
   name: 'write_file',
   label: '写入文件',
-  description: '将内容写入指定路径的文件。这是一个原子操作：自动创建所需目录和文件，无需先检查文件是否存在。如果文件已存在则会覆盖。',
+  description: '将内容写入指定路径的文件。如果文件已存在则追加内容，不存在则创建新文件。自动创建所需目录。',
   parameters: WriteFileParamsSchema,
 
   /**
@@ -47,18 +48,29 @@ export const writeFileTool = {
       const dir = dirname(path);
       mkdirSync(dir, { recursive: true });
 
-      // 写入文件
-      writeFileSync(path, content, 'utf-8');
+      // 检查文件是否存在
+      const fileExists = existsSync(path);
 
-      return {
-        content: [{ type: 'text', text: `文件已成功写入: ${path}` }],
-        details: { path }
-      };
+      if (fileExists) {
+        // 文件已存在，追加内容
+        appendFileSync(path, content, 'utf-8');
+        return {
+          content: [{ type: 'text', text: `内容已追加到文件: ${path}` }],
+          details: { path, created: false }
+        };
+      } else {
+        // 文件不存在，创建新文件
+        writeFileSync(path, content, 'utf-8');
+        return {
+          content: [{ type: 'text', text: `文件已创建并写入: ${path}` }],
+          details: { path, created: true }
+        };
+      }
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       return {
         content: [{ type: 'text', text: `写入文件失败: ${errorMsg}` }],
-        details: { path }
+        details: { path, created: false }
       };
     }
   }

--- a/tests/unit/tools/write-file.test.ts
+++ b/tests/unit/tools/write-file.test.ts
@@ -42,7 +42,7 @@ describe('writeFileTool', () => {
   });
 
   describe('execute', () => {
-    it('should write file content successfully', async () => {
+    it('should create new file and write content', async () => {
       const testFile = join(testDir, 'test.txt');
       
       // 执行写入操作
@@ -54,7 +54,8 @@ describe('writeFileTool', () => {
       // 验证返回结构
       expect(result.content).toBeDefined();
       expect(result.content[0].type).toBe('text');
-      expect(result.content[0].text).toContain('成功');
+      expect(result.content[0].text).toContain('创建');
+      expect(result.details.created).toBe(true);
       
       // 验证文件实际写入
       expect(readFileSync(testFile, 'utf-8')).toBe('Hello, Miniclaw!');
@@ -70,23 +71,28 @@ describe('writeFileTool', () => {
       });
       
       // 验证返回结构
-      expect(result.content[0].text).toContain('成功');
+      expect(result.content[0].text).toContain('创建');
+      expect(result.details.created).toBe(true);
       
       // 验证文件实际写入
       expect(readFileSync(testFile, 'utf-8')).toBe('Nested file');
     });
 
-    it('should overwrite existing file', async () => {
-      const testFile = join(testDir, 'overwrite.txt');
+    it('should append to existing file instead of overwriting', async () => {
+      const testFile = join(testDir, 'append.txt');
       
-      // 第一次写入
-      await writeFileTool.execute('', { path: testFile, content: 'Old content' });
+      // 第一次写入（创建文件）
+      const result1 = await writeFileTool.execute('', { path: testFile, content: 'First line\n' });
+      expect(result1.content[0].text).toContain('创建');
+      expect(result1.details.created).toBe(true);
       
-      // 第二次写入（覆盖）
-      await writeFileTool.execute('', { path: testFile, content: 'New content' });
+      // 第二次写入（追加）
+      const result2 = await writeFileTool.execute('', { path: testFile, content: 'Second line\n' });
+      expect(result2.content[0].text).toContain('追加');
+      expect(result2.details.created).toBe(false);
       
-      // 验证文件被覆盖
-      expect(readFileSync(testFile, 'utf-8')).toBe('New content');
+      // 验证文件内容被追加，不是覆盖
+      expect(readFileSync(testFile, 'utf-8')).toBe('First line\nSecond line\n');
     });
 
     it('should write UTF-8 content', async () => {
@@ -99,7 +105,7 @@ describe('writeFileTool', () => {
       });
       
       // 验证返回结构
-      expect(result.content[0].text).toContain('成功');
+      expect(result.content[0].text).toContain('创建');
       
       // 验证 UTF-8 内容正确写入
       expect(readFileSync(testFile, 'utf-8')).toBe('你好，世界！🌍');


### PR DESCRIPTION
## 修改内容

- 文件存在时追加内容，不覆盖
- 文件不存在时创建新文件
- 返回 `details.created` 标识是创建还是追加
- 更新测试用例匹配新行为

## 测试

```bash
npm test -- --testNamePattern "writeFileTool"
# 8 tests passed
```

## 关联 Issue

Closes #1