### PR TITLE
feat: 添加 web_search 网页搜索工具

### DIFF
--- a/docs/REQUIREMENTS_V5.md
+++ b/docs/REQUIREMENTS_V5.md
@@ -196,7 +196,6 @@ class SkillManager {
 |------|----------|----------|--------|------|
 | **web_search** | ✅ | ❌ | P2 | 网页搜索 |
 | **sessions_spawn** | ✅ | ❌ | P2 | 子代理 |
-| **nodes** | ✅ | ❌ | P2 | 设备控制（手机/电脑） |
 | **message** | ✅ | ❌ | P2 | 跨通道消息发送 |
 | **cron** | ✅ | ❌ | P2 | 定时任务 |
 | **browser** | ✅ | ❌ | P3 | 浏览器控制 |
@@ -230,24 +229,7 @@ interface SpawnParams {
 // 创建独立的子代理执行任务
 ```
 
-**3. nodes（设备控制）**
-
-```typescript
-interface NodesParams {
-  action: 'status' | 'camera_snap' | 'screen_record' | 'location_get' | 'notify' | 'run';
-  nodeId?: string;
-  // 根据不同 action 有不同参数
-}
-
-// 支持操作：
-// - camera_snap: 拍照
-// - screen_record: 屏幕录制
-// - location_get: 获取位置
-// - notify: 发送通知
-// - run: 执行命令
-```
-
-**4. message（跨通道消息）**
+**3. message（跨通道消息）**
 
 ```typescript
 interface MessageParams {
@@ -260,7 +242,7 @@ interface MessageParams {
 // 跨通道发送消息
 ```
 
-**5. cron（定时任务）**
+**4. cron（定时任务）**
 
 ```typescript
 interface CronParams {
@@ -274,7 +256,7 @@ interface CronParams {
 
 #### P3 能力详情
 
-**6. browser（浏览器控制）**
+**5. browser（浏览器控制）**
 
 ```typescript
 interface BrowserParams {
@@ -287,7 +269,7 @@ interface BrowserParams {
 // 浏览器自动化操作
 ```
 
-**7. image（图像处理）**
+**6. image（图像处理）**
 
 ```typescript
 interface ImageParams {
@@ -298,7 +280,7 @@ interface ImageParams {
 // 图像描述或生成
 ```
 
-**8. canvas（Canvas 展示）**
+**7. canvas（Canvas 展示）**
 
 ```typescript
 interface CanvasParams {
@@ -339,7 +321,6 @@ interface CanvasParams {
 |------|------|--------|
 | web_search 工具 | 1h | P2 |
 | sessions_spawn 工具 | 2h | P2 |
-| nodes 工具（设备控制） | 3h | P2 |
 | message 工具（跨通道消息） | 1.5h | P2 |
 | cron 工具 | 1.5h | P2 |
 | browser 工具 | 3h | P3 |
@@ -368,7 +349,6 @@ interface CanvasParams {
 
 - [ ] web_search 可搜索网页
 - [ ] sessions_spawn 可创建子代理
-- [ ] nodes 可控制设备（拍照/录屏/位置）
 - [ ] message 可跨通道发送消息
 - [ ] cron 可创建定时任务
 

--- a/docs/REQUIREMENTS_V5.md
+++ b/docs/REQUIREMENTS_V5.md
@@ -200,7 +200,6 @@ class SkillManager {
 | **message** | ✅ | ❌ | P2 | 跨通道消息发送 |
 | **cron** | ✅ | ❌ | P2 | 定时任务 |
 | **browser** | ✅ | ❌ | P3 | 浏览器控制 |
-| **tts** | ✅ | ❌ | P3 | 文字转语音 |
 | **image** | ✅ | ❌ | P3 | 图像处理 |
 | **pdf** | ✅ | ❌ | P3 | PDF 处理 |
 | **canvas** | ✅ | ❌ | P3 | Canvas 展示 |
@@ -288,18 +287,7 @@ interface BrowserParams {
 // 浏览器自动化操作
 ```
 
-**7. tts（文字转语音）**
-
-```typescript
-interface TTSParams {
-  text: string;
-  voice?: string;
-}
-
-// 调用 TTS API 转语音
-```
-
-**8. image（图像处理）**
+**7. image（图像处理）**
 
 ```typescript
 interface ImageParams {
@@ -310,7 +298,7 @@ interface ImageParams {
 // 图像描述或生成
 ```
 
-**9. canvas（Canvas 展示）**
+**8. canvas（Canvas 展示）**
 
 ```typescript
 interface CanvasParams {
@@ -355,7 +343,6 @@ interface CanvasParams {
 | message 工具（跨通道消息） | 1.5h | P2 |
 | cron 工具 | 1.5h | P2 |
 | browser 工具 | 3h | P3 |
-| tts 工具 | 1h | P3 |
 | image 工具 | 2h | P3 |
 | canvas 工具 | 2h | P3 |
 

--- a/docs/REQUIREMENTS_V5.md
+++ b/docs/REQUIREMENTS_V5.md
@@ -1,0 +1,344 @@
+# Miniclaw 五期需求文档 (v0.5)
+
+> 记忆自动同步 + 技能系统 + 基础能力增强
+
+## 一、背景
+
+### 1.1 当前状态 (2026-03-23)
+
+**已完成模块：**
+
+| 模块 | 状态 | 说明 |
+|------|------|------|
+| Gateway | ✅ | 统一消息入口 |
+| Router | ✅ | 消息路由 |
+| SessionManager | ✅ | Session 管理 |
+| AgentRegistry | ✅ | Agent 实例管理 |
+| SimpleMemoryStorage | ✅ | 对话历史持久化 |
+| MemorySearchManager | ✅ | 记忆搜索 |
+| Channels | ✅ | CLI/API/Web/Feishu 通道 |
+| Tools | ✅ | 文件/Shell/网络/记忆工具 |
+
+**待解决问题：**
+
+| 问题 | 影响 | 原因 |
+|------|------|------|
+| 短期记忆不会转长期记忆 | 用户需要手动整理知识库 | 没有自动同步机制 |
+| 缺少技能系统 | 无法扩展专业能力 | 没有插件/技能架构 |
+| 基础能力不足 | 功能受限 | 工具数量少 |
+
+---
+
+## 二、核心需求
+
+### 2.1 记忆自动同步（P1）
+
+**目标：** 用户无感的情况下，将短期记忆自动转化为长期记忆。
+
+#### 设计方案
+
+```
+对话产生 → 发射事件 → 累积增量 → 达到阈值 → 提取摘要 → 写入 memory/*.md
+```
+
+#### 核心组件
+
+| 组件 | 功能 |
+|------|------|
+| `SessionUpdateEmitter` | 事件发射/监听 |
+| `MemorySyncManager` | 增量累积、阈值触发 |
+| `MemoryExtractor` | 提取关键信息 |
+
+#### 配置参数
+
+| 参数 | 默认值 | 说明 |
+|------|--------|------|
+| `deltaBytes` | 50KB | 累积字节触发阈值 |
+| `deltaMessages` | 20 | 累积消息数触发阈值 |
+| `debounceMs` | 5000ms | 防抖间隔 |
+
+#### 存储格式
+
+```
+~/.miniclaw/memory/
+├── MEMORY.md           # 手动维护的主知识库
+└── sessions/           # 自动同步的对话记忆
+    └── 2026-03-23.md   # 按日期存储
+```
+
+#### 接口设计
+
+```typescript
+// 事件发射器
+type SessionUpdateListener = (sessionKey: string) => void;
+
+export function onSessionUpdate(listener: SessionUpdateListener): () => void;
+export function emitSessionUpdate(sessionKey: string): void;
+
+// 同步管理器
+interface SyncConfig {
+  deltaBytes: number;      // 51200
+  deltaMessages: number;   // 20
+  debounceMs: number;      // 5000
+  enabled: boolean;
+}
+
+class MemorySyncManager {
+  constructor(config: SyncConfig);
+  startWatching(): void;
+  stopWatching(): void;
+}
+
+// 信息提取器
+interface ExtractedInfo {
+  topic: string;
+  content: string;
+  importance: number;  // 1-5
+  timestamp: Date;
+}
+
+class MemoryExtractor {
+  extractFromMessages(messages: Message[]): ExtractedInfo[];
+}
+```
+
+---
+
+### 2.2 技能系统（P2）
+
+**目标：** 支持可扩展的技能模块，让 miniclaw 具备专业能力。
+
+#### 设计参考
+
+参考 OpenClaw 的技能系统：
+- `skills/weather/`: 天气查询
+- `skills/github/`: GitHub 操作
+- `skills/coding-agent/`: 编码代理
+- `skills/skill-creator/`: 技能创建器
+
+#### 技能结构
+
+```
+~/.miniclaw/skills/
+├── weather/
+│   ├── SKILL.md         # 技能描述和触发词
+│   ├── index.ts         # 技能实现
+│   └── config.json      # 技能配置
+│
+├── github/
+│   ├── SKILL.md
+│   ├── index.ts
+│   └── config.json
+│
+└── custom/
+    └── my-skill/
+        └── SKILL.md
+```
+
+#### SKILL.md 格式
+
+```markdown
+# Weather Skill
+
+## Description
+查询天气和天气预报
+
+## Triggers
+- 天气
+- 天气预报
+- 气温
+- 下雨
+
+## Tools
+- web_fetch: 获取天气数据
+
+## Config
+\`\`\`json
+{
+  "api": "wttr.in",
+  "defaultLocation": "Beijing"
+}
+\`\`\`
+```
+
+#### 技能加载流程
+
+```
+启动 → 扫描 skills/ 目录 → 加载 SKILL.md → 注册触发词 → 匹配时执行
+```
+
+#### 接口设计
+
+```typescript
+interface Skill {
+  id: string;
+  name: string;
+  description: string;
+  triggers: string[];
+  tools?: string[];
+  execute: (input: string, context: SkillContext) => Promise<string>;
+}
+
+class SkillManager {
+  loadSkills(dir: string): void;
+  matchSkill(input: string): Skill | null;
+  executeSkill(skill: Skill, input: string): Promise<string>;
+}
+```
+
+---
+
+### 2.3 基础能力增强（P2-P3）
+
+#### 对比 OpenClaw，miniclaw 缺少的重要能力：
+
+| 能力 | OpenClaw | Miniclaw | 优先级 |
+|------|----------|----------|--------|
+| **web_search** | ✅ web-search.ts | ❌ | P2 |
+| **sessions_spawn** | ✅ 子代理 | ❌ | P2 |
+| **tts** | ✅ 文字转语音 | ❌ | P3 |
+| **cron** | ✅ 定时任务 | ❌ | P2 |
+| **image** | ✅ 图像处理 | ❌ | P3 |
+| **pdf** | ✅ PDF 处理 | ❌ | P3 |
+| **browser** | ✅ 浏览器控制 | ❌ | P3 |
+
+#### P2 能力详情
+
+**1. web_search（网页搜索）**
+
+```typescript
+interface WebSearchParams {
+  query: string;
+  count?: number;  // 1-10
+  country?: string; // US, CN, etc.
+}
+
+// 使用 Brave Search API
+```
+
+**2. sessions_spawn（子代理）**
+
+```typescript
+interface SpawnParams {
+  task: string;
+  agentId?: string;
+  timeout?: number;
+}
+
+// 创建独立的子代理执行任务
+```
+
+**3. cron（定时任务）**
+
+```typescript
+interface CronParams {
+  schedule: string;  // cron 表达式
+  action: string;
+  message?: string;
+}
+
+// 定时执行任务或提醒
+```
+
+#### P3 能力详情
+
+**4. tts（文字转语音）**
+
+```typescript
+interface TTSParams {
+  text: string;
+  voice?: string;
+}
+
+// 调用 TTS API 转语音
+```
+
+**5. image（图像处理）**
+
+```typescript
+interface ImageParams {
+  action: 'describe' | 'generate';
+  input: string;
+}
+
+// 图像描述或生成
+```
+
+---
+
+## 三、实施计划
+
+### Phase 1: 记忆自动同步（P1）
+
+| 任务 | 工时 | 状态 |
+|------|------|------|
+| SessionUpdateEmitter 实现 | 0.5h | ⏳ 待开发 |
+| MemorySyncManager 实现 | 1h | ⏳ 待开发 |
+| MemoryExtractor 实现 | 1h | ⏳ 待开发 |
+| Gateway 集成 | 0.5h | ⏳ 待开发 |
+| 测试 | 1h | ⏳ 待开发 |
+
+### Phase 2: 技能系统（P2）
+
+| 任务 | 工时 | 状态 |
+|------|------|------|
+| SkillManager 实现 | 1.5h | ⏳ 待开发 |
+| SKILL.md 解析器 | 0.5h | ⏳ 待开发 |
+| 示例技能（weather） | 0.5h | ⏳ 待开发 |
+| 测试 | 1h | ⏳ 待开发 |
+
+### Phase 3: 基础能力增强（P2-P3）
+
+| 任务 | 工时 | 优先级 |
+|------|------|--------|
+| web_search 工具 | 1h | P2 |
+| sessions_spawn 工具 | 2h | P2 |
+| cron 工具 | 1.5h | P2 |
+| tts 工具 | 1h | P3 |
+| image 工具 | 2h | P3 |
+
+---
+
+## 四、验收标准
+
+### 4.1 记忆自动同步
+
+- [ ] 对话累积到阈值后自动同步
+- [ ] 提取的关键信息写入 memory/sessions/*.md
+- [ ] memory_search 可搜索到自动同步的内容
+- [ ] 可配置开启/关闭
+
+### 4.2 技能系统
+
+- [ ] 支持 skills/ 目录自动加载
+- [ ] 支持 SKILL.md 定义技能
+- [ ] 支持触发词匹配
+- [ ] 至少提供 1 个示例技能
+
+### 4.3 基础能力
+
+- [ ] web_search 可搜索网页
+- [ ] sessions_spawn 可创建子代理
+- [ ] cron 可创建定时任务
+
+---
+
+## 五、风险与对策
+
+| 风险 | 影响 | 对策 |
+|------|------|------|
+| 技能加载慢 | 启动时间长 | 懒加载 + 缓存 |
+| 信息提取不准确 | 长期记忆质量差 | 简单关键词提取 + 后续优化 |
+| 子代理资源占用 | 内存/CPU 消耗 | 数量限制 + 超时清理 |
+
+---
+
+## 六、变更记录
+
+| 日期 | 版本 | 变更内容 |
+|------|------|----------|
+| 2026-03-23 | v0.5.0 | 五期需求文档：记忆自动同步 + 技能系统 + 基础能力增强 |
+
+---
+
+_待确认后执行_

--- a/docs/REQUIREMENTS_V5.md
+++ b/docs/REQUIREMENTS_V5.md
@@ -188,7 +188,90 @@ class SkillManager {
 
 ---
 
-### 2.3 基础能力增强（P2-P3）
+### 2.3 多 Agent 协作（P1）
+
+**目标：** 支持主代理创建子代理并行执行任务。
+
+#### 架构设计
+
+```
+主 Agent (main)
+     │
+     │ sessions_spawn
+     ▼
+┌─────────────┐    ┌─────────────┐
+│ Subagent 1  │    │ Subagent 2  │
+│ (etf 分析)  │    │ (政策分析)   │
+└─────────────┘    └─────────────┘
+     │                  │
+     └──────────────────┘
+                ▼
+          结果汇总到主 Agent
+```
+
+#### 核心概念
+
+| 概念 | 说明 |
+|------|------|
+| **Main Agent** | 主代理，处理用户对话 |
+| **Subagent** | 子代理，执行特定任务 |
+| **spawn** | 创建子代理 |
+| **steer** | 向子代理发送指令 |
+| **collect** | 收集子代理结果 |
+
+#### 接口设计
+
+```typescript
+// sessions_spawn: 创建子代理
+interface SpawnParams {
+  task: string;           // 任务描述
+  agentId?: string;       // 指定 agent 类型
+  timeout?: number;       // 超时时间
+  mode: 'run' | 'session'; // run=一次性, session=持久
+}
+
+// subagents: 管理子代理
+interface SubagentsParams {
+  action: 'list' | 'kill' | 'steer';
+  target?: string;        // 子代理 ID
+  message?: string;       // steer 时发送的消息
+}
+```
+
+#### Agent 类型配置
+
+```typescript
+// 配置文件
+{
+  "agents": {
+    "main": { "model": "qwen-turbo" },
+    "etf": { 
+      "model": "qwen-plus",
+      "systemPrompt": "你是 ETF 分析专家..."
+    },
+    "policy": {
+      "model": "qwen-plus", 
+      "systemPrompt": "你是政策分析专家..."
+    }
+  }
+}
+```
+
+#### 使用场景
+
+```
+用户: "帮我分析 ETF 市场和政策环境"
+
+主 Agent:
+  1. sessions_spawn({ task: "分析 ETF 市场", agentId: "etf" })
+  2. sessions_spawn({ task: "分析政策环境", agentId: "policy" })
+  3. 等待两个子代理完成
+  4. 汇总结果返回给用户
+```
+
+---
+
+### 2.4 基础能力增强（P2-P3）
 
 #### 对比 OpenClaw，miniclaw 缺少的重要能力：
 
@@ -306,7 +389,17 @@ interface CanvasParams {
 | Gateway 集成 | 0.5h | ⏳ 待开发 |
 | 测试 | 1h | ⏳ 待开发 |
 
-### Phase 2: 技能系统（P2）
+### Phase 2: 多 Agent 协作（P1）
+
+| 任务 | 工时 | 状态 |
+|------|------|------|
+| Agent 类型配置支持 | 1h | ⏳ 待开发 |
+| sessions_spawn 工具 | 2h | ⏳ 待开发 |
+| subagents 工具 | 1h | ⏳ 待开发 |
+| 结果收集机制 | 1h | ⏳ 待开发 |
+| 测试 | 1h | ⏳ 待开发 |
+
+### Phase 3: 技能系统（P2）
 
 | 任务 | 工时 | 状态 |
 |------|------|------|
@@ -315,7 +408,7 @@ interface CanvasParams {
 | 示例技能（weather） | 0.5h | ⏳ 待开发 |
 | 测试 | 1h | ⏳ 待开发 |
 
-### Phase 3: 基础能力增强（P2-P3）
+### Phase 4: 基础能力增强（P2-P3）
 
 | 任务 | 工时 | 优先级 |
 |------|------|--------|
@@ -338,7 +431,15 @@ interface CanvasParams {
 - [ ] memory_search 可搜索到自动同步的内容
 - [ ] 可配置开启/关闭
 
-### 4.2 技能系统
+### 4.2 多 Agent 协作
+
+- [ ] 可通过 sessions_spawn 创建子代理
+- [ ] 可指定 agentId 创建不同类型的子代理
+- [ ] 子代理并行执行任务
+- [ ] 主代理可收集子代理结果
+- [ ] 支持 subagents list/kill/steer 操作
+
+### 4.3 技能系统
 
 - [ ] 支持 skills/ 目录自动加载
 - [ ] 支持 SKILL.md 定义技能
@@ -369,6 +470,7 @@ interface CanvasParams {
 | 日期 | 版本 | 变更内容 |
 |------|------|----------|
 | 2026-03-23 | v0.5.0 | 五期需求文档：记忆自动同步 + 技能系统 + 基础能力增强 |
+| 2026-03-23 | v0.5.1 | 新增多 Agent 协作设计；移除 nodes、tts 功能 |
 
 ---
 

--- a/docs/REQUIREMENTS_V5.md
+++ b/docs/REQUIREMENTS_V5.md
@@ -192,15 +192,18 @@ class SkillManager {
 
 #### 对比 OpenClaw，miniclaw 缺少的重要能力：
 
-| 能力 | OpenClaw | Miniclaw | 优先级 |
-|------|----------|----------|--------|
-| **web_search** | ✅ web-search.ts | ❌ | P2 |
-| **sessions_spawn** | ✅ 子代理 | ❌ | P2 |
-| **tts** | ✅ 文字转语音 | ❌ | P3 |
-| **cron** | ✅ 定时任务 | ❌ | P2 |
-| **image** | ✅ 图像处理 | ❌ | P3 |
-| **pdf** | ✅ PDF 处理 | ❌ | P3 |
-| **browser** | ✅ 浏览器控制 | ❌ | P3 |
+| 能力 | OpenClaw | Miniclaw | 优先级 | 说明 |
+|------|----------|----------|--------|------|
+| **web_search** | ✅ | ❌ | P2 | 网页搜索 |
+| **sessions_spawn** | ✅ | ❌ | P2 | 子代理 |
+| **nodes** | ✅ | ❌ | P2 | 设备控制（手机/电脑） |
+| **message** | ✅ | ❌ | P2 | 跨通道消息发送 |
+| **cron** | ✅ | ❌ | P2 | 定时任务 |
+| **browser** | ✅ | ❌ | P3 | 浏览器控制 |
+| **tts** | ✅ | ❌ | P3 | 文字转语音 |
+| **image** | ✅ | ❌ | P3 | 图像处理 |
+| **pdf** | ✅ | ❌ | P3 | PDF 处理 |
+| **canvas** | ✅ | ❌ | P3 | Canvas 展示 |
 
 #### P2 能力详情
 
@@ -228,7 +231,37 @@ interface SpawnParams {
 // 创建独立的子代理执行任务
 ```
 
-**3. cron（定时任务）**
+**3. nodes（设备控制）**
+
+```typescript
+interface NodesParams {
+  action: 'status' | 'camera_snap' | 'screen_record' | 'location_get' | 'notify' | 'run';
+  nodeId?: string;
+  // 根据不同 action 有不同参数
+}
+
+// 支持操作：
+// - camera_snap: 拍照
+// - screen_record: 屏幕录制
+// - location_get: 获取位置
+// - notify: 发送通知
+// - run: 执行命令
+```
+
+**4. message（跨通道消息）**
+
+```typescript
+interface MessageParams {
+  action: 'send';
+  target: string;    // 目标用户/群组
+  message: string;
+  channel?: string;  // feishu/discord/telegram 等
+}
+
+// 跨通道发送消息
+```
+
+**5. cron（定时任务）**
 
 ```typescript
 interface CronParams {
@@ -242,7 +275,20 @@ interface CronParams {
 
 #### P3 能力详情
 
-**4. tts（文字转语音）**
+**6. browser（浏览器控制）**
+
+```typescript
+interface BrowserParams {
+  action: 'open' | 'click' | 'type' | 'screenshot' | 'close';
+  url?: string;
+  selector?: string;
+  text?: string;
+}
+
+// 浏览器自动化操作
+```
+
+**7. tts（文字转语音）**
 
 ```typescript
 interface TTSParams {
@@ -253,7 +299,7 @@ interface TTSParams {
 // 调用 TTS API 转语音
 ```
 
-**5. image（图像处理）**
+**8. image（图像处理）**
 
 ```typescript
 interface ImageParams {
@@ -262,6 +308,18 @@ interface ImageParams {
 }
 
 // 图像描述或生成
+```
+
+**9. canvas（Canvas 展示）**
+
+```typescript
+interface CanvasParams {
+  action: 'present' | 'hide' | 'navigate';
+  url?: string;
+  html?: string;
+}
+
+// 在 Canvas 中展示内容
 ```
 
 ---
@@ -293,9 +351,13 @@ interface ImageParams {
 |------|------|--------|
 | web_search 工具 | 1h | P2 |
 | sessions_spawn 工具 | 2h | P2 |
+| nodes 工具（设备控制） | 3h | P2 |
+| message 工具（跨通道消息） | 1.5h | P2 |
 | cron 工具 | 1.5h | P2 |
+| browser 工具 | 3h | P3 |
 | tts 工具 | 1h | P3 |
 | image 工具 | 2h | P3 |
+| canvas 工具 | 2h | P3 |
 
 ---
 
@@ -319,6 +381,8 @@ interface ImageParams {
 
 - [ ] web_search 可搜索网页
 - [ ] sessions_spawn 可创建子代理
+- [ ] nodes 可控制设备（拍照/录屏/位置）
+- [ ] message 可跨通道发送消息
 - [ ] cron 可创建定时任务
 
 ---

--- a/specs/005-web-search-tool/plan.md
+++ b/specs/005-web-search-tool/plan.md
@@ -1,0 +1,178 @@
+# Implementation Plan: Web Search Tool
+
+**Feature Branch**: `005-web-search-tool`
+**Created**: 2026-03-23
+
+## Clarification Summary
+
+| 决策项 | 选择 |
+|--------|------|
+| API Key 来源 | 环境变量 `BRAVE_SEARCH_API_KEY` |
+| 默认 count | 5 |
+| 默认 country | 不指定（全球） |
+| API 超时 | 5秒 |
+| 无结果时 | 返回空数组 |
+
+---
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                   Miniclaw Agent                             │
+├─────────────────────────────────────────────────────────────┤
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │                    Tools                              │   │
+│  │  read_file │ write_file │ shell │ web_fetch │        │   │
+│  │  memory_search │ memory_get │ web_search (新增) │     │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                                                             │
+│  ┌─────────────────────────────────────────────────────┐   │
+│  │              WebSearchTool (新增)                     │   │
+│  │  - execute(query, count, country)                    │   │
+│  │  - 调用 Brave Search API                              │   │
+│  │  - 返回 [{title, url, snippet}]                       │   │
+│  └─────────────────────────────────────────────────────┘   │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## File Structure
+
+```
+src/tools/
+├── web-search.ts        # web_search 工具 (新增)
+└── index.ts             # 工具注册 (修改)
+
+tests/unit/tools/
+└── web-search.test.ts   # 单元测试 (新增)
+```
+
+---
+
+## Implementation Phases
+
+### Phase 1: Tool Implementation (TDD Red → Green)
+
+**Step 1.1: Write Test (Red)**
+
+创建测试文件，定义预期行为：
+
+```typescript
+// tests/unit/tools/web-search.test.ts
+describe('web_search tool', () => {
+  it('should have correct tool name', () => {});
+  it('should return search results', () => {});
+  it('should respect count parameter', () => {});
+  it('should handle API errors gracefully', () => {});
+  it('should return empty array when no results', () => {});
+});
+```
+
+**Step 1.2: Implement Tool (Green)**
+
+创建工具实现：
+
+```typescript
+// src/tools/web-search.ts
+export const webSearchTool = {
+  name: 'web_search',
+  label: '网页搜索',
+  description: '搜索网页获取信息',
+  parameters: WebSearchParamsSchema,
+  execute: async (_toolCallId, params) => {
+    // 调用 Brave Search API
+    // 返回结果
+  }
+};
+```
+
+**Step 1.3: Register Tool**
+
+修改 `src/tools/index.ts`：
+
+```typescript
+import { webSearchTool } from './web-search.js';
+
+export function getBuiltinTools() {
+  return [
+    // ... existing tools
+    webSearchTool,
+  ];
+}
+```
+
+---
+
+## Brave Search API Integration
+
+### API Endpoint
+
+```
+GET https://api.search.brave.com/res/v1/web/search
+```
+
+### Request Headers
+
+```
+Accept: application/json
+Accept-Encoding: gzip
+X-Subscription-Token: {API_KEY}
+```
+
+### Request Parameters
+
+| 参数 | 说明 |
+|------|------|
+| q | 搜索关键词 |
+| count | 结果数量 (1-10) |
+| country | 国家代码 |
+
+### Response Format
+
+```json
+{
+  "web": {
+    "results": [
+      {
+        "title": "Result Title",
+        "url": "https://example.com",
+        "description": "Snippet text..."
+      }
+    ]
+  }
+}
+```
+
+---
+
+## Error Handling
+
+| 错误场景 | 处理方式 |
+|----------|----------|
+| API Key 未配置 | 返回错误提示 |
+| API 超时 | 返回错误提示 |
+| 网络错误 | 返回错误提示 |
+| 无结果 | 返回空数组 |
+
+---
+
+## Time Estimate
+
+| Phase | Duration |
+|-------|----------|
+| Phase 1: TDD 实现 | 1h |
+| **Total** | **1h** |
+
+---
+
+## Next Steps
+
+1. 创建测试文件（Red）
+2. 运行测试确认失败
+3. 实现工具代码（Green）
+4. 运行测试确认通过
+5. 注册工具

--- a/specs/005-web-search-tool/spec.md
+++ b/specs/005-web-search-tool/spec.md
@@ -1,0 +1,78 @@
+# Feature Specification: Web Search Tool
+
+**Feature Branch**: `005-web-search-tool`
+**Created**: 2026-03-23
+**Status**: Draft
+
+## User Scenarios & Testing
+
+### User Story 1 - Agent Searches the Web (Priority: P1)
+
+As an AI Agent, I want to search the web for information so that I can provide up-to-date answers to user questions.
+
+**Acceptance Scenarios**:
+
+1. **Given** the user asks "What is the latest news about ETF?", **When** the Agent calls `web_search` with query "ETF latest news", **Then** relevant search results are returned with titles, URLs, and snippets
+2. **Given** the Agent calls `web_search` with count=5, **When** results are returned, **Then** exactly 5 results are returned
+3. **Given** the Agent calls `web_search` with country="CN", **When** results are returned, **Then** results are localized for China
+
+---
+
+### User Story 2 - Agent Handles Search Errors Gracefully (Priority: P2)
+
+As an AI Agent, I want search errors to be handled gracefully so that I can inform the user appropriately.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Brave Search API is unavailable, **When** the Agent calls `web_search`, **Then** an appropriate error message is returned
+2. **Given** the query is empty, **When** the Agent calls `web_search`, **Then** an error is returned indicating invalid input
+
+---
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a `web_search` tool that accepts a query string
+- **FR-002**: The tool MUST support optional `count` parameter (1-10, default 5)
+- **FR-003**: The tool MUST support optional `country` parameter for localization
+- **FR-004**: The tool MUST use Brave Search API
+- **FR-005**: Results MUST include title, URL, and snippet for each result
+- **FR-006**: The tool MUST handle API errors gracefully
+
+### Non-Functional Requirements
+
+- **NFR-001**: Response time should be under 5 seconds
+- **NFR-002**: No external dependencies beyond Node.js built-ins
+
+---
+
+## Success Criteria
+
+- **SC-001**: `web_search` tool returns results for valid queries
+- **SC-002**: Tool respects count parameter
+- **SC-003**: Tool handles errors gracefully
+- **SC-004**: Unit test coverage >= 80%
+
+---
+
+## Key Entities
+
+```typescript
+interface WebSearchParams {
+  query: string;
+  count?: number;    // 1-10, default 5
+  country?: string;  // US, CN, etc.
+}
+
+interface WebSearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+interface WebSearchResponse {
+  results: WebSearchResult[];
+  error?: string;
+}
+```

--- a/specs/005-web-search-tool/tasks.md
+++ b/specs/005-web-search-tool/tasks.md
@@ -1,0 +1,158 @@
+# Tasks: Web Search Tool
+
+**Input**: specs/005-web-search-tool/spec.md, plan.md
+
+---
+
+## Phase 1: TDD Implementation
+
+### T001 [P] Write test file
+
+**File**: `tests/unit/tools/web-search.test.ts`
+
+**Test cases**:
+- should have correct tool name
+- should return search results for valid query
+- should respect count parameter
+- should handle API errors gracefully
+- should return empty array when no results
+
+**Acceptance**:
+- [ ] Test file created
+- [ ] Tests fail (Red)
+
+---
+
+### T002 Implement web_search tool
+
+**File**: `src/tools/web-search.ts`
+
+**Implementation**:
+```typescript
+import { Type, type Static } from '@sinclair/typebox';
+
+const WebSearchParamsSchema = Type.Object({
+  query: Type.String({ description: '搜索关键词' }),
+  count: Type.Optional(Type.Number({ minimum: 1, maximum: 10, description: '结果数量 (1-10)' })),
+  country: Type.Optional(Type.String({ description: '国家代码 (US, CN, etc.)' })),
+});
+
+type WebSearchParams = Static<typeof WebSearchParamsSchema>;
+
+interface WebSearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+export const webSearchTool = {
+  name: 'web_search',
+  label: '网页搜索',
+  description: '搜索网页获取最新信息。返回标题、链接和摘要。',
+  parameters: WebSearchParamsSchema,
+  
+  async execute(_toolCallId: string, params: WebSearchParams) {
+    const apiKey = process.env.BRAVE_SEARCH_API_KEY;
+    if (!apiKey) {
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ error: 'BRAVE_SEARCH_API_KEY not configured', results: [] }) }],
+        details: { error: 'API key not configured' }
+      };
+    }
+
+    const count = params.count ?? 5;
+    const url = new URL('https://api.search.brave.com/res/v1/web/search');
+    url.searchParams.set('q', params.query);
+    url.searchParams.set('count', String(count));
+    if (params.country) {
+      url.searchParams.set('country', params.country);
+    }
+
+    try {
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+          'Accept-Encoding': 'gzip',
+          'X-Subscription-Token': apiKey,
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!response.ok) {
+        return {
+          content: [{ type: 'text', text: JSON.stringify({ error: `API error: ${response.status}`, results: [] }) }],
+          details: { error: `API error: ${response.status}` }
+        };
+      }
+
+      const data = await response.json() as any;
+      const results: WebSearchResult[] = (data?.web?.results ?? []).map((r: any) => ({
+        title: r.title ?? '',
+        url: r.url ?? '',
+        snippet: r.description ?? '',
+      }));
+
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ results }, null, 2) }],
+        details: { count: results.length }
+      };
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{ type: 'text', text: JSON.stringify({ error: errorMsg, results: [] }) }],
+        details: { error: errorMsg }
+      };
+    }
+  }
+};
+```
+
+**Acceptance**:
+- [ ] Tool file created
+- [ ] Tests pass (Green)
+
+---
+
+### T003 Register tool in index
+
+**File**: `src/tools/index.ts`
+
+**Changes**:
+```typescript
+import { webSearchTool } from './web-search.js';
+
+export { ..., webSearchTool };
+
+export function getBuiltinTools() {
+  return [
+    // ... existing tools
+    webSearchTool,
+  ];
+}
+```
+
+**Acceptance**:
+- [ ] Tool exported
+- [ ] Tool in getBuiltinTools()
+
+---
+
+## Summary
+
+| Phase | Tasks | Est. Time |
+|-------|-------|-----------|
+| Phase 1 | T001-T003 | 1h |
+
+---
+
+## Execution Order (TDD)
+
+```
+1. T001: Write tests (Red)
+2. Run tests → Confirm failure
+3. T002: Implement tool (Green)
+4. Run tests → Confirm pass
+5. T003: Register tool
+6. Run full test suite
+```

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,8 +8,9 @@ import { shellTool } from './shell.js';
 import { webFetchTool } from './web-fetch.js';
 import { memorySearchTool } from './memory-search.js';
 import { memoryGetTool } from './memory-get.js';
+import { webSearchTool } from './web-search.js';
 
-export { readFileTool, writeFileTool, shellTool, webFetchTool, memorySearchTool, memoryGetTool };
+export { readFileTool, writeFileTool, shellTool, webFetchTool, memorySearchTool, memoryGetTool, webSearchTool };
 
 /**
  * 获取所有内置工具列表
@@ -21,6 +22,7 @@ export function getBuiltinTools() {
     shellTool,
     webFetchTool,
     memorySearchTool,
-    memoryGetTool
+    memoryGetTool,
+    webSearchTool
   ];
 }

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview 网页搜索工具
+ *
+ * 使用 Brave Search API 搜索网页信息。
+ *
+ * @module tools/web-search
+ */
+
+import { Type, type Static } from '@sinclair/typebox';
+
+/**
+ * 工具参数 Schema
+ */
+const WebSearchParamsSchema = Type.Object({
+  query: Type.String({ description: '搜索关键词' }),
+  count: Type.Optional(Type.Number({ minimum: 1, maximum: 10, description: '结果数量 (1-10，默认 5)' })),
+  country: Type.Optional(Type.String({ description: '国家代码 (US, CN, etc.)' })),
+});
+
+type WebSearchParams = Static<typeof WebSearchParamsSchema>;
+
+/**
+ * 搜索结果
+ */
+interface WebSearchResult {
+  title: string;
+  url: string;
+  snippet: string;
+}
+
+/**
+ * web_search 工具
+ *
+ * 搜索网页获取最新信息。返回标题、链接和摘要。
+ */
+export const webSearchTool = {
+  name: 'web_search',
+  label: '网页搜索',
+  description: `搜索网页获取最新信息。
+
+参数：
+- query: 搜索关键词
+- count: 结果数量 (1-10，默认 5)
+- country: 国家代码 (US, CN, etc.)
+
+返回搜索结果列表，包含标题、链接和摘要。`,
+  parameters: WebSearchParamsSchema,
+
+  /**
+   * 执行搜索
+   */
+  async execute(_toolCallId: string, params: WebSearchParams) {
+    // 检查 API Key
+    const apiKey = process.env.BRAVE_SEARCH_API_KEY;
+    if (!apiKey) {
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            error: 'BRAVE_SEARCH_API_KEY not configured',
+            results: []
+          })
+        }],
+        details: { error: 'API key not configured' }
+      };
+    }
+
+    // 构建请求
+    const count = params.count ?? 5;
+    const url = new URL('https://api.search.brave.com/res/v1/web/search');
+    url.searchParams.set('q', params.query);
+    url.searchParams.set('count', String(count));
+    if (params.country) {
+      url.searchParams.set('country', params.country);
+    }
+
+    try {
+      // 调用 Brave Search API
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers: {
+          'Accept': 'application/json',
+          'Accept-Encoding': 'gzip',
+          'X-Subscription-Token': apiKey,
+        },
+        signal: AbortSignal.timeout(5000),
+      });
+
+      // 处理错误响应
+      if (!response.ok) {
+        return {
+          content: [{
+            type: 'text',
+            text: JSON.stringify({
+              error: `API error: ${response.status}`,
+              results: []
+            })
+          }],
+          details: { error: `API error: ${response.status}` }
+        };
+      }
+
+      // 解析响应
+      const data = await response.json() as any;
+      const results: WebSearchResult[] = (data?.web?.results ?? []).map((r: any) => ({
+        title: r.title ?? '',
+        url: r.url ?? '',
+        snippet: r.description ?? '',
+      }));
+
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({ results }, null, 2)
+        }],
+        details: { count: results.length }
+      };
+    } catch (err) {
+      const errorMsg = err instanceof Error ? err.message : String(err);
+      return {
+        content: [{
+          type: 'text',
+          text: JSON.stringify({
+            error: errorMsg,
+            results: []
+          })
+        }],
+        details: { error: errorMsg }
+      };
+    }
+  }
+};

--- a/tests/unit/tools/web-search.test.ts
+++ b/tests/unit/tools/web-search.test.ts
@@ -127,4 +127,49 @@ describe('web_search tool', () => {
     expect(parsed.error).toContain('429');
     expect(parsed.results).toEqual([]);
   });
+
+  it('should include country parameter when provided', async () => {
+    process.env.BRAVE_SEARCH_API_KEY = 'test-api-key';
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        web: { results: [] }
+      })
+    });
+    global.fetch = mockFetch;
+
+    await webSearchTool.execute('test-1', { query: 'test', country: 'CN' });
+
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('country=CN');
+  });
+
+  it('should handle network errors gracefully', async () => {
+    process.env.BRAVE_SEARCH_API_KEY = 'test-api-key';
+
+    const mockFetch = vi.fn().mockRejectedValue(new Error('Network error'));
+    global.fetch = mockFetch;
+
+    const result = await webSearchTool.execute('test-1', { query: 'test' });
+
+    const text = result.content[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.error).toContain('Network error');
+    expect(parsed.results).toEqual([]);
+  });
+
+  it('should handle non-Error thrown values', async () => {
+    process.env.BRAVE_SEARCH_API_KEY = 'test-api-key';
+
+    const mockFetch = vi.fn().mockRejectedValue('Unknown error string');
+    global.fetch = mockFetch;
+
+    const result = await webSearchTool.execute('test-1', { query: 'test' });
+
+    const text = result.content[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.error).toContain('Unknown error string');
+    expect(parsed.results).toEqual([]);
+  });
 });

--- a/tests/unit/tools/web-search.test.ts
+++ b/tests/unit/tools/web-search.test.ts
@@ -1,0 +1,130 @@
+/**
+ * @fileoverview web_search 工具测试
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { webSearchTool } from '../../../src/tools/web-search';
+
+describe('web_search tool', () => {
+  const originalEnv = process.env.BRAVE_SEARCH_API_KEY;
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    if (originalEnv) {
+      process.env.BRAVE_SEARCH_API_KEY = originalEnv;
+    } else {
+      delete process.env.BRAVE_SEARCH_API_KEY;
+    }
+  });
+
+  it('should have correct tool name', () => {
+    expect(webSearchTool.name).toBe('web_search');
+  });
+
+  it('should have tool description', () => {
+    expect(webSearchTool.description).toBeTruthy();
+    expect(webSearchTool.description.length).toBeGreaterThan(10);
+  });
+
+  it('should return error when API key not configured', async () => {
+    delete process.env.BRAVE_SEARCH_API_KEY;
+
+    const result = await webSearchTool.execute('test-1', { query: 'test' });
+
+    expect(result.content[0].type).toBe('text');
+    const text = result.content[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.error).toContain('not configured');
+    expect(parsed.results).toEqual([]);
+  });
+
+  it('should return search results for valid query', async () => {
+    process.env.BRAVE_SEARCH_API_KEY = 'test-api-key';
+
+    // Mock fetch
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        web: {
+          results: [
+            { title: 'Test Result', url: 'https://example.com', description: 'Test snippet' }
+          ]
+        }
+      })
+    });
+    global.fetch = mockFetch;
+
+    const result = await webSearchTool.execute('test-1', { query: 'test query' });
+
+    expect(mockFetch).toHaveBeenCalled();
+    const text = result.content[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.results).toHaveLength(1);
+    expect(parsed.results[0].title).toBe('Test Result');
+    expect(parsed.results[0].url).toBe('https://example.com');
+  });
+
+  it('should respect count parameter', async () => {
+    process.env.BRAVE_SEARCH_API_KEY = 'test-api-key';
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        web: {
+          results: [
+            { title: 'Result 1', url: 'https://example1.com', description: 'Snippet 1' },
+            { title: 'Result 2', url: 'https://example2.com', description: 'Snippet 2' },
+            { title: 'Result 3', url: 'https://example3.com', description: 'Snippet 3' }
+          ]
+        }
+      })
+    });
+    global.fetch = mockFetch;
+
+    await webSearchTool.execute('test-1', { query: 'test', count: 2 });
+
+    // Check that count was passed to API
+    const calledUrl = mockFetch.mock.calls[0][0];
+    expect(calledUrl).toContain('count=2');
+  });
+
+  it('should return empty array when no results', async () => {
+    process.env.BRAVE_SEARCH_API_KEY = 'test-api-key';
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        web: {
+          results: []
+        }
+      })
+    });
+    global.fetch = mockFetch;
+
+    const result = await webSearchTool.execute('test-1', { query: 'nonexistent query xyz123' });
+
+    const text = result.content[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.results).toEqual([]);
+  });
+
+  it('should handle API errors gracefully', async () => {
+    process.env.BRAVE_SEARCH_API_KEY = 'test-api-key';
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+    });
+    global.fetch = mockFetch;
+
+    const result = await webSearchTool.execute('test-1', { query: 'test' });
+
+    const text = result.content[0].text;
+    const parsed = JSON.parse(text);
+    expect(parsed.error).toContain('429');
+    expect(parsed.results).toEqual([]);
+  });
+});


### PR DESCRIPTION
## 功能

使用 Brave Search API 搜索网页信息。

### 参数

| 参数 | 说明 |
|------|------|
| query | 搜索关键词 |
| count | 结果数量 (1-10，默认 5) |
| country | 国家代码 (US, CN, etc.) |

### 返回



## 配置

需要设置环境变量：
```bash
export BRAVE_SEARCH_API_KEY=your-api-key
```

## 测试

```
✓ 7 tests passed
✓ 全部 281 tests passed
```

## 开发流程

按 TDD 模式开发：
1. 写测试（Red）
2. 实现代码（Green）
3. 注册工具