### PR TITLE
feat: add web-search tool and config.json agents loading

### DIFF
--- a/docs/REQUIREMENTS_V7.md
+++ b/docs/REQUIREMENTS_V7.md
@@ -1,0 +1,287 @@
+# Miniclaw 七期需求文档 (v0.7)
+
+> web_search 工具 + 配置文件加载
+
+## 一、背景
+
+### 1.1 当前状态 (2026-03-27)
+
+**已完成模块：**
+
+| 模块 | 状态 | 说明 |
+|------|:----:|------|
+| Gateway | ✅ | 统一消息入口 |
+| Router | ✅ | 消息路由 |
+| SessionManager | ✅ | Session 管理 |
+| AgentRegistry | ✅ | Agent 实例管理（多类型） |
+| SimpleMemoryStorage | ✅ | 对话历史持久化 |
+| MemorySearchManager | ✅ | 记忆搜索 |
+| SkillManager | ✅ | 技能系统 |
+| SubagentManager | ✅ | 子代理管理 |
+| Channels | ✅ | CLI/API/Web/Feishu 通道 |
+| Tools | ✅ | 文件/Shell/网络/记忆工具 |
+| config.json 加载 | ✅ | Agent 配置文件加载 |
+
+**已配置 Agent 类型：**
+
+| Agent ID | 名称 | 模型 | 说明 |
+|----------|------|------|------|
+| main | 影子 | qwen3.5-plus | 主代理 |
+| etf | ETF 分析师 | qwen-plus | ETF 市场分析 |
+| policy | 政策分析师 | qwen-plus | 宏观政策分析 |
+
+### 1.2 待解决问题
+
+| 问题 | 影响 | 原因 |
+|------|------|------|
+| 子代理无搜索能力 | 无法获取实时信息 | 缺少 web_search 工具 |
+| ETF Agent 功能受限 | 无法分析市场行情 | 没有数据来源 |
+
+---
+
+## 二、web_search 工具设计（P1）
+
+### 2.1 技术选型
+
+**方案：DuckDuckGo Instant Answer API**
+
+| 特性 | 说明 |
+|------|------|
+| 免费额度 | 无限制 |
+| API Key | 不需要 |
+| 中文支持 | 一般（英文最佳） |
+| 响应速度 | 快 |
+
+**对比其他方案：**
+
+| 方案 | 免费额度 | API Key | 推荐度 |
+|------|---------|:-------:|:------:|
+| **DuckDuckGo** | 无限制 | ❌ | ⭐⭐⭐ |
+| SerpAPI | 100次/月 | ✅ | ⭐⭐ |
+| Bing Search | 1000次/月 | ✅ | ⭐⭐ |
+
+### 2.2 API 说明
+
+**端点：**
+```
+GET https://api.duckduckgo.com/?q={query}&format=json&no_html=1&skip_disambig=1
+```
+
+**参数：**
+| 参数 | 类型 | 说明 |
+|------|------|------|
+| q | string | 搜索关键词 |
+| format | string | 固定 "json" |
+| no_html | number | 1（去除HTML） |
+| skip_disambig | number | 1（跳过消歧） |
+
+**返回示例：**
+```json
+{
+  "Abstract": "摘要文本",
+  "AbstractText": "纯文本摘要",
+  "AbstractSource": "Wikipedia",
+  "AbstractURL": "https://...",
+  "Heading": "标题",
+  "RelatedTopics": [
+    {
+      "Text": "相关主题描述",
+      "FirstURL": "https://..."
+    }
+  ],
+  "Results": [
+    {
+      "Text": "结果文本",
+      "FirstURL": "https://..."
+    }
+  ]
+}
+```
+
+### 2.3 工具接口设计
+
+**文件位置：** `src/tools/web-search.ts`
+
+**参数定义：**
+```typescript
+interface WebSearchParams {
+  query: string;           // 搜索关键词（必填）
+  maxResults?: number;     // 最大结果数，默认5
+}
+
+const WebSearchParamsSchema = Type.Object({
+  query: Type.String({ description: '搜索关键词' }),
+  maxResults: Type.Optional(Type.Number({ 
+    description: '最大结果数，默认5',
+    default: 5 
+  }))
+});
+```
+
+**返回格式：**
+```
+搜索结果：{query}
+
+1. {title}
+   {snippet}
+   链接：{url}
+
+2. {title}
+   {snippet}
+   链接：{url}
+
+...
+```
+
+### 2.4 核心实现
+
+```typescript
+// src/tools/web-search.ts
+
+import { Type, type Static } from '@sinclair/typebox';
+
+const WebSearchParamsSchema = Type.Object({
+  query: Type.String({ description: '搜索关键词' }),
+  maxResults: Type.Optional(Type.Number({ 
+    description: '最大结果数，默认5',
+    default: 5 
+  }))
+});
+
+type WebSearchParams = Static<typeof WebSearchParamsSchema>;
+
+interface DuckDuckGoResponse {
+  Abstract?: string;
+  AbstractText?: string;
+  AbstractSource?: string;
+  AbstractURL?: string;
+  Heading?: string;
+  RelatedTopics?: Array<{
+    Text?: string;
+    FirstURL?: string;
+  }>;
+  Results?: Array<{
+    Text?: string;
+    FirstURL?: string;
+  }>;
+}
+
+export const webSearchTool = {
+  name: 'web_search',
+  label: '网页搜索',
+  description: '使用 DuckDuckGo 搜索网页信息。适用于：查询最新资讯、技术文档、概念解释。NOT for: 实时股价、敏感数据。',
+  parameters: WebSearchParamsSchema,
+
+  async execute(
+    toolCallId: string,
+    params: WebSearchParams,
+    signal?: AbortSignal
+  ) {
+    const { query, maxResults = 5 } = params;
+
+    try {
+      const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+      
+      const response = await fetch(url, { signal });
+      const data: DuckDuckGoResponse = await response.json();
+
+      const results: WebSearchResult[] = [];
+
+      // 主摘要
+      if (data.AbstractText) {
+        results.push({
+          title: data.Heading || '摘要',
+          snippet: data.AbstractText,
+          url: data.AbstractURL || '',
+          source: data.AbstractSource
+        });
+      }
+
+      // 相关主题
+      if (data.RelatedTopics) {
+        for (const topic of data.RelatedTopics.slice(0, maxResults - results.length)) {
+          if (topic.Text && topic.FirstURL) {
+            results.push({
+              title: topic.Text.split(' - ')[0] || '相关主题',
+              snippet: topic.Text,
+              url: topic.FirstURL
+            });
+          }
+        }
+      }
+
+      // 格式化输出
+      if (results.length === 0) {
+        return {
+          content: [{ type: 'text', text: `未找到 "${query}" 的相关结果` }],
+          details: { query, count: 0 }
+        };
+      }
+
+      const output = results.map((r, i) => 
+        `${i + 1}. ${r.title}\n   ${r.snippet}\n   链接：${r.url}`
+      ).join('\n\n');
+
+      return {
+        content: [{ type: 'text', text: `搜索结果：${query}\n\n${output}` }],
+        details: { query, count: results.length }
+      };
+
+    } catch (err) {
+      return {
+        content: [{ 
+          type: 'text', 
+          text: `搜索失败: ${err instanceof Error ? err.message : err}` 
+        }],
+        details: { query, error: true }
+      };
+    }
+  }
+};
+```
+
+### 2.5 集成步骤
+
+| 步骤 | 文件 | 操作 |
+|:----:|------|------|
+| 1 | `src/tools/web-search.ts` | 创建新工具文件 |
+| 2 | `src/tools/index.ts` | 导出新工具 |
+| 3 | `tests/unit/tools/web-search.test.ts` | 添加单元测试 |
+| 4 | - | 编译测试 |
+
+---
+
+## 三、验收标准
+
+### 3.1 功能验收
+
+- [ ] `web_search` 工具可正常调用
+- [ ] 返回格式化的搜索结果
+- [ ] 支持中文搜索
+- [ ] 错误处理完善
+
+### 3.2 测试验收
+
+- [ ] 单元测试覆盖率 > 80%
+- [ ] 集成测试通过
+- [ ] 边界情况测试（空结果、网络错误等）
+
+---
+
+## 四、实施计划
+
+| 任务 | 预计时间 | 优先级 |
+|------|:--------:|:------:|
+| 创建 web-search.ts | 15分钟 | P1 |
+| 编写单元测试 | 10分钟 | P1 |
+| 集成到工具列表 | 5分钟 | P1 |
+| 测试验证 | 10分钟 | P1 |
+| **总计** | **40分钟** | - |
+
+---
+
+## 五、变更记录
+
+| 日期 | 版本 | 变更内容 |
+|------|------|----------|
+| 2026-03-27 | v0.7.0 | 七期需求文档：web_search 工具设计 |

--- a/specs/008-web-search-tool/plan.md
+++ b/specs/008-web-search-tool/plan.md
@@ -1,0 +1,298 @@
+# Development Plan: Web Search Tool (DuckDuckGo)
+
+**Feature Branch**: `008-web-search-tool`  
+**Created**: 2026-03-27  
+**Status**: Draft  
+**Spec**: specs/008-web-search-tool/spec.md
+
+## Tech Stack
+
+| Component | Technology | Notes |
+|-----------|------------|-------|
+| HTTP Client | Node.js built-in `fetch` | 无需额外依赖 |
+| 参数验证 | @sinclair/typebox | 项目已有依赖 |
+| 测试框架 | Vitest | 项目已有配置 |
+| Mock | Vitest vi.fn() | 单元测试 mock |
+
+## File Structure
+
+```
+miniclaw/
+├── src/
+│   └── tools/
+│       ├── index.ts              # [修改] 添加 webSearchTool 导出
+│       └── web-search.ts          # [新建] web_search 工具实现
+└── tests/
+    └── unit/
+        └── tools/
+            └── web-search.test.ts # [新建] 单元测试
+```
+
+## Implementation Steps
+
+### Step 1: 创建工具定义 (web-search.ts)
+
+**文件**: `src/tools/web-search.ts`
+
+**实现内容**:
+
+1. **TypeBox Schema 定义**
+   - `WebSearchParamsSchema`: 参数验证 schema
+   - 必填参数: `query` (string)
+   - 可选参数: `maxResults` (number, default=5)
+
+2. **接口定义**
+   ```typescript
+   interface DuckDuckGoResponse {
+     Abstract?: string;
+     AbstractText?: string;
+     AbstractSource?: string;
+     AbstractURL?: string;
+     Heading?: string;
+     RelatedTopics?: Array<{
+       Text?: string;
+       FirstURL?: string;
+     }>;
+     Results?: Array<{
+       Text?: string;
+       FirstURL?: string;
+     }>;
+   }
+   
+   interface WebSearchResult {
+     title: string;
+     snippet: string;
+     url: string;
+     source?: string;
+   }
+   ```
+
+3. **工具导出对象**
+   ```typescript
+   export const webSearchTool = {
+     name: 'web_search',
+     label: '搜索网页',
+     description: '搜索网页信息，返回相关结果（使用 DuckDuckGo）',
+     parameters: WebSearchParamsSchema,
+     execute: async (toolCallId, params, signal) => {...}
+   }
+   ```
+
+### Step 2: 实现 execute 函数
+
+**核心逻辑**:
+
+1. **参数验证**
+   - 检查 query 非空
+   - 处理 maxResults 默认值和边界值 (min=1, max=10)
+
+2. **URL 构建**
+   ```typescript
+   const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+   ```
+
+3. **请求发送**
+   - 使用 fetch API
+   - 设置合理超时 (默认 10000ms)
+   - 支持 AbortSignal 传递
+
+4. **响应解析**
+   - 解析 DuckDuckGo JSON 响应
+   - 提取 Abstract 和 RelatedTopics
+   - 格式化返回结果
+
+5. **结果格式化**
+   - 返回文本格式结果
+   - 包含 details 元信息
+
+### Step 3: 错误处理
+
+**场景覆盖**:
+
+| 错误场景 | 处理方式 |
+|---------|---------|
+| 空查询 | 返回错误提示 "请提供搜索关键词" |
+| maxResults <= 0 | 自动修正为 1 |
+| maxResults > 10 | 自动修正为 10 |
+| 网络错误 | 返回 "搜索请求失败: {error}" |
+| 超时 | 返回 "搜索请求超时" |
+| API 返回异常 | 返回 "搜索服务暂时不可用" |
+| 无结果 | 返回 "未找到与 '{query}' 相关的结果" |
+| AbortSignal | 正确传递中止信号 |
+
+### Step 4: 注册工具到 index.ts
+
+**文件**: `src/tools/index.ts`
+
+**修改内容**:
+```typescript
+import { webSearchTool } from './web-search.js';
+
+export { 
+  // ... existing exports
+  webSearchTool 
+};
+
+export function getBuiltinTools() {
+  return [
+    // ... existing tools
+    webSearchTool
+  ];
+}
+```
+
+### Step 5: 创建单元测试
+
+**文件**: `tests/unit/tools/web-search.test.ts`
+
+## Test Plan
+
+### Test Structure
+
+```
+web-search.test.ts
+├── tool definition tests
+│   ├── 验证工具名称
+│   ├── 验证工具描述
+│   └── 验证参数 schema
+├── execute - 正常流程
+│   ├── 返回抽象摘要
+│   ├── 返回相关主题
+│   └── 遵守 maxResults 限制
+├── execute - 参数边界
+│   ├── 空查询返回错误
+│   ├── maxResults=0 自动修正
+│   ├── maxResults>10 自动修正
+│   └── maxResults 默认值
+├── execute - 错误处理
+│   ├── 网络错误处理
+│   ├── 超时处理
+│   ├── AbortSignal 处理
+│   ├── API 返回异常格式
+│   └── API 返回空对象
+├── execute - 无结果场景
+│   ├── 冷门关键词无结果
+│   └── 返回友好提示
+└── execute - URL 编码
+    └── 特殊字符正确编码
+```
+
+### Test Cases
+
+| ID | 场景 | 输入 | 期望输出 | Mock |
+|----|------|------|---------|------|
+| T1 | 工具名称正确 | - | name='web_search' | - |
+| T2 | 工具描述完整 | - | description 存在 | - |
+| T3 | 参数 schema 正确 | - | query 必填, maxResults 可选 | - |
+| T4 | 空查询返回错误 | query='' | 包含 "请提供搜索关键词" | - |
+| T5 | 正常搜索返回结果 | query='test' | content 数组有内容 | Mock fetch |
+| T6 | 遵守 maxResults | query='test', maxResults=2 | 最多 2 条结果 | Mock fetch |
+| T7 | maxResults=0 自动修正 | query='test', maxResults=0 | 使用默认值 | Mock fetch |
+| T8 | maxResults>10 自动修正 | query='test', maxResults=20 | 最多 10 条结果 | Mock fetch |
+| T9 | 网络错误处理 | query='test' | 包含 "搜索请求失败" | Mock fetch reject |
+| T10 | 超时处理 | query='test', timeout=1 | 包含 "搜索请求超时" | Mock AbortError |
+| T11 | 无结果友好提示 | query='test' | 包含 "未找到" | Mock 空响应 |
+| T12 | API 异常格式 | query='test' | 返回错误提示 | Mock 无效 JSON |
+| T13 | 特殊字符编码 | query='量子计算 原理' | URL 编码正确 | Mock fetch |
+| T14 | 中文搜索有效 | query='量子计算' | 返回中文结果 | Mock fetch |
+
+### Coverage Goals
+
+| 类型 | 目标覆盖率 |
+|------|----------|
+| Statements | >= 80% |
+| Branches | >= 75% |
+| Functions | >= 90% |
+| Lines | >= 80% |
+
+### Mock Strategy
+
+```typescript
+// Mock DuckDuckGo API 响应
+const mockDDGResponse = {
+  Abstract: 'Test abstract',
+  AbstractText: 'Test abstract text',
+  AbstractSource: 'Wikipedia',
+  AbstractURL: 'https://example.com',
+  Heading: 'Test Heading',
+  RelatedTopics: [
+    { Text: 'Topic 1 - Description', FirstURL: 'https://example.com/1' },
+    { Text: 'Topic 2 - Description', FirstURL: 'https://example.com/2' }
+  ]
+};
+
+// Mock fetch
+global.fetch = vi.fn().mockResolvedValue({
+  ok: true,
+  json: () => Promise.resolve(mockDDGResponse)
+});
+```
+
+## Dependencies Check
+
+| 依赖 | 状态 | 备注 |
+|------|------|------|
+| Node.js fetch | ✅ 内置 | Node 18+ |
+| @sinclair/typebox | ✅ 已有 | 参数验证 |
+| Vitest | ✅ 已有 | 测试框架 |
+
+## API Reference
+
+### DuckDuckGo Instant Answer API
+
+**Endpoint**: `https://api.duckduckgo.com/`
+
+**参数**:
+| 参数 | 值 | 说明 |
+|------|---|------|
+| q | {query} | 搜索关键词 (需 URL 编码) |
+| format | json | 返回格式 |
+| no_html | 1 | 移除 HTML 标签 |
+| skip_disambig | 1 | 跳过消歧页 |
+
+**响应字段**:
+| 字段 | 说明 |
+|------|------|
+| Abstract | 摘要内容 (HTML) |
+| AbstractText | 摘要内容 (纯文本) |
+| AbstractSource | 摘要来源 |
+| AbstractURL | 摘要链接 |
+| Heading | 标题 |
+| RelatedTopics | 相关主题数组 |
+| Results | 额外结果数组 |
+
+**限制**:
+- 无需 API Key
+- 有隐式速率限制
+- 适合轻量级搜索场景
+
+## Estimated Effort
+
+| 步骤 | 预计时间 |
+|------|---------|
+| Step 1: 工具定义 | 15 min |
+| Step 2: execute 实现 | 30 min |
+| Step 3: 错误处理 | 20 min |
+| Step 4: 注册工具 | 5 min |
+| Step 5: 单元测试 | 40 min |
+| **总计** | **~2 小时** |
+
+## Risks & Mitigations
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|---------|
+| DuckDuckGo API 不可用 | 高 | 优雅错误处理，返回友好提示 |
+| API 响应格式变化 | 中 | 防御性解析，处理缺失字段 |
+| 中文搜索结果质量 | 低 | 接受现状，文档说明限制 |
+| 速率限制 | 低 | 文档说明，无 API Key 限制 |
+
+## Acceptance Checklist
+
+完成以下检查后方可进入 implement 阶段：
+
+- [ ] plan.md 已创建
+- [ ] 文件结构清晰
+- [ ] 实现步骤明确
+- [ ] 测试用例完整
+- [ ] 错误处理覆盖
+- [ ] 无外部依赖新增

--- a/specs/008-web-search-tool/spec.md
+++ b/specs/008-web-search-tool/spec.md
@@ -1,0 +1,156 @@
+# Feature Specification: Web Search Tool (DuckDuckGo)
+
+**Feature Branch**: `008-web-search-tool`  
+**Created**: 2026-03-27  
+**Status**: Draft  
+**Input**: 需求文档 docs/REQUIREMENTS_V7.md - web_search 工具设计，使用 DuckDuckGo Instant Answer API
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Agent 获取实时信息 (Priority: P1)
+
+作为 AI Agent，我希望能够搜索网页信息，以便为用户提供最新的、实时的答案。
+
+**Why this priority**: 这是核心功能，解决子代理无搜索能力的问题，是整个工具存在的根本价值。
+
+**Independent Test**: 可以通过调用 `web_search` 工具并验证返回结果来完全测试，无需依赖其他功能。
+
+**Acceptance Scenarios**:
+
+1. **Given** 用户询问 "ETF 最新行情", **When** Agent 调用 `web_search` 参数 query="ETF 最新行情", **Then** 返回相关搜索结果，包含标题、摘要和链接
+2. **Given** Agent 调用 `web_search` 参数 query="TypeScript generics tutorial" maxResults=3, **When** 结果返回, **Then** 返回恰好 3 条结果
+3. **Given** Agent 调用 `web_search` 参数 query="量子计算原理", **When** 结果返回, **Then** 结果包含中文摘要和来源
+
+---
+
+### User Story 2 - Agent 优雅处理搜索错误 (Priority: P2)
+
+作为 AI Agent，我希望搜索错误能够被优雅处理，以便能够适当地告知用户。
+
+**Why this priority**: 错误处理是生产环境稳定性的保障，但优先级低于核心搜索功能。
+
+**Independent Test**: 可以通过模拟网络错误、空查询等场景独立测试错误处理逻辑。
+
+**Acceptance Scenarios**:
+
+1. **Given** DuckDuckGo API 不可用, **When** Agent 调用 `web_search`, **Then** 返回适当的错误信息而非崩溃
+2. **Given** 查询参数 query 为空字符串, **When** Agent 调用 `web_search`, **Then** 返回错误提示无效输入
+3. **Given** 请求被中止（AbortSignal）, **When** Agent 调用 `web_search`, **Then** 正确处理中止信号
+
+---
+
+### User Story 3 - Agent 获取无结果时友好反馈 (Priority: P2)
+
+作为 AI Agent，我希望搜索无结果时能收到清晰的反馈，以便告知用户没有找到相关信息。
+
+**Why this priority**: 用户体验优化，但不是核心功能。
+
+**Independent Test**: 可以通过搜索冷门关键词模拟无结果场景独立测试。
+
+**Acceptance Scenarios**:
+
+1. **Given** 搜索词过于冷门如 "xyzabc123不存在的词汇", **When** Agent 调用 `web_search`, **Then** 返回 "未找到相关结果" 的友好提示
+2. **Given** 搜索结果只有摘要无相关主题, **When** Agent 调用 `web_search`, **Then** 至少返回摘要信息
+
+---
+
+### Edge Cases
+
+- 当 DuckDuckGo API 返回格式异常（如缺少必要字段）时如何处理？
+- 当 maxResults 设置为 0 或负数时如何处理？
+- 当查询字符串包含特殊字符时如何编码？
+- 当网络请求超时时如何处理？
+- 当 API 返回空对象 {} 时如何处理？
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: 系统必须提供 `web_search` 工具，接受 query 参数（必填，搜索关键词）
+- **FR-002**: 工具必须支持可选的 `maxResults` 参数（默认值 5，限制返回结果数量）
+- **FR-003**: 工具必须使用 DuckDuckGo Instant Answer API（免费、无需 API Key）
+- **FR-004**: 结果必须包含标题(title)、摘要(snippet)、链接(url) 和来源(source，可选)
+- **FR-005**: 工具必须正确处理 AbortSignal 以支持请求中止
+- **FR-006**: 工具必须返回格式化的文本结果
+- **FR-007**: 工具必须正确编码 URL 参数（encodeURIComponent）
+- **FR-008**: 工具必须在无结果时返回友好提示
+
+### Non-Functional Requirements
+
+- **NFR-001**: 响应时间应在 5 秒以内
+- **NFR-002**: 无外部依赖，仅使用 Node.js 内置 fetch
+- **NFR-003**: 工具描述应清晰说明适用场景和限制
+- **NFR-004**: 单元测试覆盖率 >= 80%
+
+### Key Entities
+
+```typescript
+// 工具参数
+interface WebSearchParams {
+  query: string;           // 搜索关键词（必填）
+  maxResults?: number;     // 最大结果数，默认5
+}
+
+// DuckDuckGo API 响应结构
+interface DuckDuckGoResponse {
+  Abstract?: string;       // 摘要 HTML
+  AbstractText?: string;   // 摘要纯文本
+  AbstractSource?: string; // 摘要来源
+  AbstractURL?: string;    // 摘要链接
+  Heading?: string;        // 标题
+  RelatedTopics?: Array<{
+    Text?: string;         // 主题描述
+    FirstURL?: string;     // 链接
+  }>;
+  Results?: Array<{
+    Text?: string;
+    FirstURL?: string;
+  }>;
+}
+
+// 内部结果结构
+interface WebSearchResult {
+  title: string;
+  snippet: string;
+  url: string;
+  source?: string;
+}
+
+// 工具返回格式
+interface ToolResponse {
+  content: Array<{ type: 'text'; text: string }>;
+  details?: { query: string; count?: number; error?: boolean };
+}
+```
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `web_search` 工具可被正常调用并返回有效搜索结果
+- **SC-002**: 工具正确遵守 maxResults 参数限制返回结果数量
+- **SC-003**: 工具正确处理网络错误、API 错误并返回有意义的信息
+- **SC-004**: 工具正确处理空查询参数并返回错误提示
+- **SC-005**: 单元测试覆盖率 >= 80%，包含正常流程和边界情况
+- **SC-006**: 中文搜索能够返回有效结果
+- **SC-007**: 无结果时返回友好提示而非空或错误
+
+## Out of Scope
+
+- 实时股价查询（需要专门的数据源）
+- 分页搜索
+- 图片/视频搜索
+- 搜索结果缓存
+- 速率限制（DuckDuckGo 无需 API Key，但有隐式限制）
+
+## Dependencies
+
+- Node.js 内置 fetch API
+- @sinclair/typebox（参数验证，项目已有依赖）
+
+## Implementation Notes
+
+- 文件位置：`src/tools/web-search.ts`
+- 需要在 `src/tools/index.ts` 中导出
+- DuckDuckGo API 端点：`https://api.duckduckgo.com/?q={query}&format=json&no_html=1&skip_disambig=1`
+- 无需 API Key，适合轻量级搜索场景

--- a/specs/008-web-search-tool/tasks.md
+++ b/specs/008-web-search-tool/tasks.md
@@ -1,0 +1,256 @@
+# Task List: Web Search Tool (DuckDuckGo)
+
+**Feature Branch**: `008-web-search-tool`
+**Created**: 2026-03-27
+**Plan**: specs/008-web-search-tool/plan.md
+**Status**: ✅ Completed
+
+---
+
+## Task 1: 创建工具定义文件
+
+### 描述
+创建 `src/tools/web-search.ts` 文件，定义 web_search 工具的基本结构和参数 schema。
+
+### 文件
+- `src/tools/web-search.ts` [新建] ✅
+
+### 验收标准
+- [x] 导入必要的依赖 (`@sinclair/typebox`)
+- [x] 定义 `WebSearchParamsSchema`:
+  - `query`: string, 必填
+  - `maxResults`: number, 可选, 默认 5, 范围 1-10
+- [x] 定义 `DuckDuckGoResponse` 接口，包含：
+  - `Abstract`, `AbstractText`, `AbstractSource`, `AbstractURL`
+  - `Heading`
+  - `RelatedTopics` (Array of `{Text?, FirstURL?}`)
+  - `Results` (Array of `{Text?, FirstURL?}`)
+- [x] 定义 `WebSearchResult` 接口，包含：
+  - `title`: string
+  - `snippet`: string
+  - `url`: string
+  - `source?`: string
+- [x] 导出 `webSearchTool` 对象，包含：
+  - `name`: 'web_search'
+  - `label`: '搜索网页'
+  - `description`: '搜索网页信息，返回相关结果（使用 DuckDuckGo）'
+  - `parameters`: WebSearchParamsSchema
+  - `execute`: 函数占位符 (返回 "not implemented")
+
+### 预计时间
+15 分钟
+
+---
+
+## Task 2: 实现 execute 函数 - 核心逻辑
+
+### 描述
+实现 `execute` 函数的核心搜索逻辑，包括参数验证、API 调用和结果解析。
+
+### 文件
+- `src/tools/web-search.ts` [修改] ✅
+
+### 验收标准
+- [x] 参数验证:
+  - 检查 query 非空，空则返回错误提示 "请提供搜索关键词"
+  - 处理 maxResults 默认值 (5) 和边界值 (min=1, max=10)
+- [x] URL 构建:
+  ```typescript
+  const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+  ```
+- [x] HTTP 请求:
+  - 使用 `fetch` API
+  - 设置超时 10000ms
+  - 支持 `AbortSignal` 传递
+- [x] 响应解析:
+  - 解析 JSON 响应
+  - 提取 `Abstract` 和 `RelatedTopics`
+  - 合并 `Results` 数组
+- [x] 结果格式化:
+  - 返回文本格式内容
+  - 包含 `details` 元信息
+- [x] TypeScript 类型正确，无编译错误
+
+### 预计时间
+30 分钟
+
+---
+
+## Task 3: 实现错误处理
+
+### 描述
+为 execute 函数添加完整的错误处理逻辑，覆盖各种异常场景。
+
+### 文件
+- `src/tools/web-search.ts` [修改] ✅
+
+### 验收标准
+- [x] 空查询处理: 返回 `{ content: [{ type: 'text', text: '请提供搜索关键词' }] }`
+- [x] maxResults 边界处理:
+  - `maxResults <= 0`: 自动修正为 1
+  - `maxResults > 10`: 自动修正为 10
+- [x] 网络错误处理: 返回 `{ content: [{ type: 'text', text: '搜索请求失败: {error.message}' }] }`
+- [x] 超时处理: 返回 `{ content: [{ type: 'text', text: '搜索请求超时，请稍后重试' }] }`
+- [x] API 返回异常: 返回 `{ content: [{ type: 'text', text: '搜索服务暂时不可用，请稍后重试' }] }`
+- [x] 无结果处理: 返回 `{ content: [{ type: 'text', text: '未找到与 "{query}" 相关的结果' }] }`
+- [x] AbortSignal 支持: 正确传递中止信号，可被外部中断
+- [x] 所有错误路径都返回符合 ToolResult 接口的对象
+
+### 预计时间
+20 分钟
+
+---
+
+## Task 4: 注册工具到 index.ts
+
+### 描述
+在工具索引文件中导出 webSearchTool，使其可被系统发现和使用。
+
+### 文件
+- `src/tools/index.ts` [修改] ✅
+
+### 验收标准
+- [x] 导入 webSearchTool:
+  ```typescript
+  import { webSearchTool } from './web-search.js';
+  ```
+- [x] 在导出列表中添加:
+  ```typescript
+  export { webSearchTool };
+  ```
+- [x] 在 `getBuiltinTools()` 返回数组中添加 webSearchTool
+- [x] 导入路径使用 `.js` 扩展名 (ESM 规范)
+- [x] TypeScript 编译无错误
+- [x] 运行时无模块加载错误
+
+### 预计时间
+5 分钟
+
+---
+
+## Task 5: 创建单元测试文件
+
+### 描述
+创建 `tests/unit/tools/web-search.test.ts`，编写完整的单元测试覆盖所有场景。
+
+### 文件
+- `tests/unit/tools/web-search.test.ts` [新建] ✅
+
+### 验收标准
+- [x] 测试文件结构:
+  - `tool definition tests` 分组
+  - `execute - 正常流程` 分组
+  - `execute - 参数边界` 分组
+  - `execute - 错误处理` 分组
+  - `execute - 无结果场景` 分组
+  - `execute - URL 编码` 分组
+- [x] 工具定义测试 (3 个用例):
+  - 验证工具名称为 'web_search'
+  - 验证工具描述存在
+  - 验证参数 schema 正确 (query 必填, maxResults 可选)
+- [x] 正常流程测试 (3 个用例):
+  - 返回抽象摘要
+  - 返回相关主题列表
+  - 遵守 maxResults 限制
+- [x] 参数边界测试 (4 个用例):
+  - 空查询返回错误提示
+  - maxResults=0 自动修正为 1
+  - maxResults>10 自动修正为 10
+  - maxResults 默认值为 5
+- [x] 错误处理测试 (5 个用例):
+  - 网络错误返回友好提示
+  - 超时返回友好提示
+  - AbortSignal 正确传递
+  - API 返回无效 JSON
+  - API 返回空对象
+- [x] 无结果场景测试 (2 个用例):
+  - 冷门关键词无结果
+  - 返回友好提示包含搜索词
+- [x] URL 编码测试 (1 个用例):
+  - 特殊字符和中文正确编码
+- [x] Mock 策略:
+  - 使用 `vi.fn()` mock `global.fetch`
+  - 定义 `mockDDGResponse` 测试数据
+  - 每个测试后清理 mock
+- [x] 所有测试用例通过: `pnpm test tests/unit/tools/web-search.test.ts`
+- [x] 测试覆盖率达标:
+  - Statements >= 80%
+  - Branches >= 75%
+  - Functions >= 90%
+  - Lines >= 80%
+
+### 预计时间
+40 分钟
+
+---
+
+## Task 6: 集成验证
+
+### 描述
+验证工具可以正确集成到 miniclaw 系统并被调用。
+
+### 文件
+- 无新文件
+
+### 验收标准
+- [x] TypeScript 编译通过: `pnpm build`
+- [x] 所有测试通过: `pnpm test`
+- [x] 工具可被 `getBuiltinTools()` 发现
+- [x] 手动测试调用:
+  ```typescript
+  const result = await webSearchTool.execute('test-id', { query: 'Node.js' }, null);
+  console.log(result);
+  ```
+- [x] 验证返回格式符合 ToolResult 接口
+
+### 预计时间
+10 分钟
+
+---
+
+## Summary
+
+| 任务 | 预计时间 | 状态 |
+|------|---------|------|
+| Task 1: 创建工具定义文件 | 15 min | ✅ Completed |
+| Task 2: 实现 execute 函数 | 30 min | ✅ Completed |
+| Task 3: 实现错误处理 | 20 min | ✅ Completed |
+| Task 4: 注册工具到 index.ts | 5 min | ✅ Completed |
+| Task 5: 创建单元测试 | 40 min | ✅ Completed |
+| Task 6: 集成验证 | 10 min | ✅ Completed |
+| **总计** | **~2 小时** | **✅ Done** |
+
+---
+
+## Execution Order
+
+推荐按以下顺序执行：
+
+```
+Task 1 → Task 2 → Task 3 → Task 4 → Task 5 → Task 6
+```
+
+Task 1-3 可以合并为一个 PR，Task 5 可以并行开发。
+Task 6 必须在所有任务完成后执行。
+
+---
+
+## Dependencies
+
+```mermaid
+graph LR
+    T1[Task 1: 工具定义] --> T2[Task 2: execute 实现]
+    T2 --> T3[Task 3: 错误处理]
+    T3 --> T4[Task 4: 注册工具]
+    T3 --> T5[Task 5: 单元测试]
+    T4 --> T6[Task 6: 集成验证]
+    T5 --> T6
+```
+
+---
+
+## Notes
+
+- DuckDuckGo API 无需 API Key，但有隐式速率限制
+- 适合轻量级搜索场景，不支持复杂搜索语法
+- 中文搜索结果质量取决于 DuckDuckGo

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -1,9 +1,10 @@
 /**
  * 配置模块
- * 管理应用配置，支持环境变量加载
+ * 管理应用配置，支持环境变量和 config.json 加载
  */
 import { join } from 'path';
 import { homedir } from 'os';
+import { existsSync, readFileSync } from 'fs';
 
 /**
  * 百炼配置
@@ -156,6 +157,22 @@ export function loadConfig(): Config {
       encryptKey: process.env.MINICLAW_FEISHU_ENCRYPT_KEY,
       verificationToken: process.env.MINICLAW_FEISHU_VERIFICATION_TOKEN
     };
+  }
+
+  // 加载 config.json 中的 agents 配置
+  const configPath = getConfigPath();
+  if (existsSync(configPath)) {
+    try {
+      const fileContent = readFileSync(configPath, 'utf-8');
+      const jsonConfig = JSON.parse(fileContent);
+
+      if (jsonConfig.agents) {
+        config.agents = jsonConfig.agents;
+        console.log(`[Config] 从 ${configPath} 加载了 ${jsonConfig.agents.list?.length || 0} 个 Agent 配置`);
+      }
+    } catch (err) {
+      console.warn(`[Config] 加载 ${configPath} 失败:`, err instanceof Error ? err.message : err);
+    }
   }
 
   return config;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,10 +6,11 @@ import { readFileTool } from './read-file.js';
 import { writeFileTool } from './write-file.js';
 import { shellTool } from './shell.js';
 import { webFetchTool } from './web-fetch.js';
+import { webSearchTool } from './web-search.js';
 import { memorySearchTool } from './memory-search.js';
 import { memoryGetTool } from './memory-get.js';
 
-export { readFileTool, writeFileTool, shellTool, webFetchTool, memorySearchTool, memoryGetTool };
+export { readFileTool, writeFileTool, shellTool, webFetchTool, webSearchTool, memorySearchTool, memoryGetTool };
 
 /**
  * 获取所有内置工具列表
@@ -20,6 +21,7 @@ export function getBuiltinTools() {
     writeFileTool,
     shellTool,
     webFetchTool,
+    webSearchTool,
     memorySearchTool,
     memoryGetTool
   ];

--- a/src/tools/web-search.ts
+++ b/src/tools/web-search.ts
@@ -1,0 +1,252 @@
+/**
+ * 网页搜索工具
+ * 使用 DuckDuckGo Instant Answer API 进行搜索
+ */
+import { Type, type Static } from '@sinclair/typebox';
+
+/**
+ * 工具参数 schema
+ */
+const WebSearchParamsSchema = Type.Object({
+  query: Type.String({ description: '搜索关键词' }),
+  maxResults: Type.Optional(
+    Type.Number({
+      description: '最大返回结果数量（默认 5，范围 1-10）',
+      minimum: 1,
+      maximum: 10
+    })
+  )
+});
+
+type WebSearchParams = Static<typeof WebSearchParamsSchema>;
+
+/**
+ * DuckDuckGo API 响应结构
+ */
+interface DuckDuckGoResponse {
+  Abstract?: string;
+  AbstractText?: string;
+  AbstractSource?: string;
+  AbstractURL?: string;
+  Heading?: string;
+  RelatedTopics?: Array<{
+    Text?: string;
+    FirstURL?: string;
+  }>;
+  Results?: Array<{
+    Text?: string;
+    FirstURL?: string;
+  }>;
+}
+
+/**
+ * 内部搜索结果结构
+ */
+interface WebSearchResult {
+  title: string;
+  snippet: string;
+  url: string;
+  source?: string;
+}
+
+/**
+ * 工具详情类型
+ */
+export interface WebSearchDetails {
+  query: string;
+  count?: number;
+  error?: boolean;
+}
+
+/**
+ * 解析 DuckDuckGo RelatedTopics 中的标题
+ * 格式通常是 "Title - Description" 或 "Title"
+ */
+function parseTopicText(text: string): { title: string; snippet: string } {
+  const dashIndex = text.indexOf(' - ');
+  if (dashIndex > 0) {
+    return {
+      title: text.slice(0, dashIndex).trim(),
+      snippet: text.slice(dashIndex + 3).trim()
+    };
+  }
+  return { title: text.trim(), snippet: '' };
+}
+
+/**
+ * 网页搜索工具定义
+ */
+export const webSearchTool = {
+  name: 'web_search',
+  label: '搜索网页',
+  description: '搜索网页信息，返回相关结果（使用 DuckDuckGo）',
+  parameters: WebSearchParamsSchema,
+
+  /**
+   * 执行网页搜索
+   */
+  async execute(
+    _toolCallId: string,
+    params: WebSearchParams,
+    signal?: AbortSignal
+  ): Promise<{ content: Array<{ type: 'text'; text: string }>; details: WebSearchDetails }> {
+    const { query, maxResults = 5 } = params;
+
+    // 空查询检查
+    if (!query || query.trim() === '') {
+      return {
+        content: [{ type: 'text', text: '请提供搜索关键词' }],
+        details: { query: '', error: true }
+      };
+    }
+
+    // maxResults 边界处理
+    const effectiveMaxResults = Math.max(1, Math.min(10, maxResults));
+
+    // 构建 DuckDuckGo API URL
+    const url = `https://api.duckduckgo.com/?q=${encodeURIComponent(query)}&format=json&no_html=1&skip_disambig=1`;
+
+    // 创建超时控制器
+    const timeoutController = new AbortController();
+    const timeoutMs = 10000;
+    const timeoutId = setTimeout(() => timeoutController.abort(), timeoutMs);
+
+    try {
+      // 合并外部 signal 和超时 signal
+      const combinedSignal = signal
+        ? AbortSignal.any([signal, timeoutController.signal])
+        : timeoutController.signal;
+
+      // 发起请求
+      const response = await fetch(url, {
+        signal: combinedSignal,
+        headers: {
+          'User-Agent': 'Mozilla/5.0 (compatible; Miniclaw/0.1.0)'
+        }
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        return {
+          content: [{ type: 'text', text: '搜索服务暂时不可用，请稍后重试' }],
+          details: { query, error: true }
+        };
+      }
+
+      // 解析响应
+      let data: DuckDuckGoResponse;
+      try {
+        data = (await response.json()) as DuckDuckGoResponse;
+      } catch {
+        return {
+          content: [{ type: 'text', text: '搜索服务返回异常数据，请稍后重试' }],
+          details: { query, error: true }
+        };
+      }
+
+      // 收集结果
+      const results: WebSearchResult[] = [];
+
+      // 添加摘要（如果有）
+      if (data.AbstractText || data.Abstract) {
+        results.push({
+          title: data.Heading || '摘要',
+          snippet: data.AbstractText || data.Abstract || '',
+          url: data.AbstractURL || '',
+          source: data.AbstractSource
+        });
+      }
+
+      // 添加相关主题
+      if (data.RelatedTopics) {
+        for (const topic of data.RelatedTopics) {
+          if (results.length >= effectiveMaxResults) break;
+          if (topic.Text && topic.FirstURL) {
+            const parsed = parseTopicText(topic.Text);
+            results.push({
+              title: parsed.title,
+              snippet: parsed.snippet,
+              url: topic.FirstURL
+            });
+          }
+        }
+      }
+
+      // 添加额外结果
+      if (data.Results) {
+        for (const result of data.Results) {
+          if (results.length >= effectiveMaxResults) break;
+          if (result.Text && result.FirstURL) {
+            const parsed = parseTopicText(result.Text);
+            results.push({
+              title: parsed.title,
+              snippet: parsed.snippet,
+              url: result.FirstURL
+            });
+          }
+        }
+      }
+
+      // 无结果处理
+      if (results.length === 0) {
+        return {
+          content: [{ type: 'text', text: `未找到与 "${query}" 相关的结果` }],
+          details: { query, count: 0 }
+        };
+      }
+
+      // 格式化结果
+      const lines: string[] = [];
+      for (let i = 0; i < results.length; i++) {
+        const r = results[i];
+        lines.push(`\n## ${i + 1}. ${r.title}`);
+        if (r.snippet) {
+          lines.push(r.snippet);
+        }
+        if (r.url) {
+          lines.push(`链接: ${r.url}`);
+        }
+        if (r.source) {
+          lines.push(`来源: ${r.source}`);
+        }
+      }
+
+      return {
+        content: [{ type: 'text', text: `找到 ${results.length} 条与 "${query}" 相关的结果：${lines.join('\n')}` }],
+        details: { query, count: results.length }
+      };
+    } catch (err) {
+      clearTimeout(timeoutId);
+
+      if (err instanceof Error) {
+        // 处理中止错误
+        if (err.name === 'AbortError') {
+          // 检查是超时还是外部中止
+          if (timeoutController.signal.aborted && !signal?.aborted) {
+            return {
+              content: [{ type: 'text', text: '搜索请求超时，请稍后重试' }],
+              details: { query, error: true }
+            };
+          }
+          // 外部中止，不返回错误（请求被主动取消）
+          return {
+            content: [{ type: 'text', text: '搜索请求已取消' }],
+            details: { query, error: true }
+          };
+        }
+
+        // 网络错误
+        return {
+          content: [{ type: 'text', text: `搜索请求失败: ${err.message}` }],
+          details: { query, error: true }
+        };
+      }
+
+      return {
+        content: [{ type: 'text', text: `搜索请求失败: ${String(err)}` }],
+        details: { query, error: true }
+      };
+    }
+  }
+};

--- a/tests/unit/tools/web-search.test.ts
+++ b/tests/unit/tools/web-search.test.ts
@@ -1,0 +1,322 @@
+/**
+ * 网页搜索工具测试
+ * 测试 web_search 工具的各项功能
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { webSearchTool } from '../../../src/tools/web-search';
+
+describe('webSearchTool', () => {
+  // 保存原始 fetch
+  const originalFetch = global.fetch;
+
+  // Mock DuckDuckGo 响应数据
+  const mockDDGResponse = {
+    Abstract: 'Test abstract content',
+    AbstractText: 'Test abstract text',
+    AbstractSource: 'Wikipedia',
+    AbstractURL: 'https://en.wikipedia.org/wiki/Test',
+    Heading: 'Test Heading',
+    RelatedTopics: [
+      { Text: 'Topic 1 - Description of topic 1', FirstURL: 'https://example.com/1' },
+      { Text: 'Topic 2 - Description of topic 2', FirstURL: 'https://example.com/2' },
+      { Text: 'Topic 3 - Description of topic 3', FirstURL: 'https://example.com/3' }
+    ],
+    Results: [
+      { Text: 'Result 1 - Description', FirstURL: 'https://example.com/result1' }
+    ]
+  };
+
+  beforeEach(() => {
+    // 重置 mock
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    // 恢复原始 fetch
+    global.fetch = originalFetch;
+  });
+
+  describe('tool definition tests', () => {
+    it('should have correct name', () => {
+      expect(webSearchTool.name).toBe('web_search');
+    });
+
+    it('should have description', () => {
+      expect(webSearchTool.description).toContain('搜索');
+      expect(webSearchTool.description).toContain('DuckDuckGo');
+    });
+
+    it('should have parameters schema', () => {
+      expect(webSearchTool.parameters).toBeDefined();
+      expect(webSearchTool.parameters.properties.query).toBeDefined();
+      expect(webSearchTool.parameters.properties.maxResults).toBeDefined();
+      // query 是必填参数
+      expect(webSearchTool.parameters.required).toContain('query');
+    });
+  });
+
+  describe('execute - 正常流程', () => {
+    it('should return abstract summary', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockDDGResponse)
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      expect(result.content).toBeDefined();
+      expect(result.content[0].type).toBe('text');
+      expect(result.content[0].text).toContain('Test Heading');
+      expect(result.content[0].text).toContain('Test abstract text');
+      expect(result.details.query).toBe('test');
+      expect(result.details.count).toBeGreaterThan(0);
+    });
+
+    it('should return related topics', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockDDGResponse)
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      expect(result.content[0].text).toContain('Topic 1');
+      expect(result.content[0].text).toContain('https://example.com/1');
+    });
+
+    it('should respect maxResults limit', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockDDGResponse)
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test', maxResults: 2 });
+
+      // 最多返回 2 条结果
+      expect(result.details.count).toBeLessThanOrEqual(2);
+    });
+  });
+
+  describe('execute - 参数边界', () => {
+    it('should return error for empty query', async () => {
+      const result = await webSearchTool.execute('test-id', { query: '' });
+
+      expect(result.content[0].text).toContain('请提供搜索关键词');
+      expect(result.details.error).toBe(true);
+    });
+
+    it('should return error for whitespace-only query', async () => {
+      const result = await webSearchTool.execute('test-id', { query: '   ' });
+
+      expect(result.content[0].text).toContain('请提供搜索关键词');
+      expect(result.details.error).toBe(true);
+    });
+
+    it('should auto-correct maxResults=0 to 1', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockDDGResponse)
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test', maxResults: 0 });
+
+      // maxResults=0 会被修正为 1
+      expect(result.details.count).toBeLessThanOrEqual(1);
+    });
+
+    it('should auto-correct maxResults>10 to 10', async () => {
+      const manyTopicsResponse = {
+        ...mockDDGResponse,
+        RelatedTopics: Array.from({ length: 20 }, (_, i) => ({
+          Text: `Topic ${i + 1} - Description`,
+          FirstURL: `https://example.com/${i + 1}`
+        }))
+      };
+
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(manyTopicsResponse)
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test', maxResults: 20 });
+
+      // maxResults>10 会被修正为 10
+      expect(result.details.count).toBeLessThanOrEqual(10);
+    });
+
+    it('should use default maxResults=5 when not specified', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve(mockDDGResponse)
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      // 默认最多 5 条
+      expect(result.details.count).toBeLessThanOrEqual(5);
+    });
+  });
+
+  describe('execute - 错误处理', () => {
+    it('should handle network error', async () => {
+      global.fetch = vi.fn().mockRejectedValue(new Error('Network error'));
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      expect(result.content[0].text).toContain('搜索请求失败');
+      expect(result.content[0].text).toContain('Network error');
+      expect(result.details.error).toBe(true);
+    });
+
+    it('should handle timeout', async () => {
+      // 模拟超时场景：fetch 抛出 AbortError，且 timeoutController.signal.aborted 为 true
+      // 这需要通过实际触发超时来测试，这里我们模拟超时控制器的状态
+      const abortError = new Error('Aborted');
+      abortError.name = 'AbortError';
+
+      // 使用 vi.spyOn 来模拟超时场景
+      const originalSetTimeout = global.setTimeout;
+      vi.spyOn(global, 'setTimeout').mockImplementation((fn: () => void) => {
+        // 立即执行超时回调
+        fn();
+        return 0 as unknown as ReturnType<typeof setTimeout>;
+      });
+
+      global.fetch = vi.fn().mockRejectedValue(abortError);
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      // 超时或取消都会返回错误
+      expect(result.content[0].text).toBeDefined();
+      expect(result.details.error).toBe(true);
+
+      vi.restoreAllMocks();
+      global.setTimeout = originalSetTimeout;
+    });
+
+    it('should handle AbortSignal correctly', async () => {
+      const controller = new AbortController();
+      controller.abort();
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' }, controller.signal);
+
+      // 被中止的请求
+      expect(result.content[0].text).toBeDefined();
+    });
+
+    it('should handle invalid JSON response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.reject(new Error('Invalid JSON'))
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      expect(result.content[0].text).toContain('异常数据');
+      expect(result.details.error).toBe(true);
+    });
+
+    it('should handle API returning empty object', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({})
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      expect(result.content[0].text).toContain('未找到');
+      expect(result.details.count).toBe(0);
+    });
+
+    it('should handle non-OK response', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable'
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      expect(result.content[0].text).toContain('暂时不可用');
+      expect(result.details.error).toBe(true);
+    });
+
+    it('should handle non-Error rejection', async () => {
+      global.fetch = vi.fn().mockRejectedValue('string error');
+
+      const result = await webSearchTool.execute('test-id', { query: 'test' });
+
+      expect(result.content[0].text).toContain('搜索请求失败');
+      expect(result.details.error).toBe(true);
+    });
+  });
+
+  describe('execute - 无结果场景', () => {
+    it('should return friendly message for obscure keywords', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          Abstract: '',
+          AbstractText: '',
+          RelatedTopics: [],
+          Results: []
+        })
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: 'xyzabc123不存在的词汇' });
+
+      expect(result.content[0].text).toContain('未找到');
+      expect(result.content[0].text).toContain('xyzabc123不存在的词汇');
+    });
+
+    it('should include query in friendly message', async () => {
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({})
+      });
+
+      const result = await webSearchTool.execute('test-id', { query: '冷门关键词测试' });
+
+      expect(result.content[0].text).toContain('冷门关键词测试');
+    });
+  });
+
+  describe('execute - URL 编码', () => {
+    it('should correctly encode special characters and Chinese', async () => {
+      let capturedUrl = '';
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        capturedUrl = url;
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockDDGResponse)
+        });
+      });
+
+      await webSearchTool.execute('test-id', { query: '量子计算 原理' });
+
+      // 验证 URL 编码 - 中文会被编码
+      expect(capturedUrl).toContain('%E9%87%8F%E5%AD%90'); // '量子' 的 UTF-8 编码
+      expect(capturedUrl).toContain('api.duckduckgo.com');
+      expect(capturedUrl).toContain('format=json');
+      // 验证 encodeURIComponent 正确编码空格
+      expect(capturedUrl).toContain('%20'); // 空格编码
+    });
+
+    it('should encode special characters in query', async () => {
+      let capturedUrl = '';
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        capturedUrl = url;
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve(mockDDGResponse)
+        });
+      });
+
+      await webSearchTool.execute('test-id', { query: 'C++ & Java' });
+
+      // 验证特殊字符被编码
+      expect(capturedUrl).toContain('C%2B%2B'); // ++ 编码
+      expect(capturedUrl).toContain('%26'); // & 编码
+    });
+  });
+});


### PR DESCRIPTION
- Add webSearchTool using DuckDuckGo Instant Answer API
- Support loading agents config from ~/.miniclaw/config.json
- Add unit tests for web-search tool
- Add specs and requirements docs