### PR TITLE
fix: 子代理调用后结果未返回主代理问题修复

### DIFF
--- a/src/core/subagent/tools.ts
+++ b/src/core/subagent/tools.ts
@@ -137,7 +137,12 @@ export function createSessionsSpawnTool(options: SessionsSpawnToolOptions) {
 
 **重要**：遇到专业领域问题，优先使用此工具委托给专家子代理，不要自己回答。
 
-返回执行结果。`;
+**执行流程**：
+1. 调用此工具创建子代理
+2. 子代理执行任务并返回结果
+3. **必须**：基于子代理返回的结果，整理、总结后回复用户
+
+返回：子代理的执行结果（文本内容）`;
 
   return {
     name: 'sessions_spawn',


### PR DESCRIPTION
## 问题描述

当主代理调用子代理（如 ETF 分析师）处理专业问题时，子代理执行完成后结果没有正确返回给主代理，用户看不到整合后的回复。

## 问题原因

1. **工具描述不够明确**：sessions_spawn 工具的描述只说"返回执行结果"，没有明确告诉模型收到结果后需要生成最终回复
2. **systemPrompt 规则不够严格**：main 代理的提示词中规则 3 和规则 4 可能产生歧义

## 修复内容

1. **tools.ts**: 更新 sessions_spawn 工具描述，添加明确的执行流程步骤：
   - 调用工具创建子代理
   - 子代理执行任务并返回结果
   - **必须**：基于结果整理、总结后回复用户

2. **config.json**: 更新 main 代理的 systemPrompt，强调必须等待结果并生成回复

## 测试建议

重启 miniclaw 后测试：
- 发送"分析下沪深300的潜力"给 main 代理
- 观察是否调用 etf 子代理
- 确认子代理结果返回后，main 代理生成最终回复