### PR TITLE
perf: 优化日志输出

### DIFF
--- a/src/core/agent/index.ts
+++ b/src/core/agent/index.ts
@@ -574,8 +574,8 @@ export class MiniclawAgent {
     // 订阅 Agent 事件
     // Agent 在处理过程中会发出多种事件
     const unsubscribe = this.agent.subscribe((event: any) => {
-      // 记录所有事件类型（调试用）
-      this.log(`📨 收到事件: ${event.type}`);
+      // 记录所有事件类型（调试用，已禁用）
+      // this.log(`📨 收到事件: ${event.type}`);
       
       // 文本增量事件：大模型返回的文本片段
       if (event.type === 'message_update' && event.assistantMessageEvent?.type === 'text_delta') {

--- a/src/core/skill/loader.ts
+++ b/src/core/skill/loader.ts
@@ -234,15 +234,19 @@ export async function loadSkill(skillPath: string): Promise<LoadSkillResult> {
 export async function loadAllSkills(skillsDir: string): Promise<Skill[]> {
   const skills: Skill[] = [];
   
+  console.log(`[SkillLoader] Loading skills from: ${skillsDir}`);
+  
   // 确保目录存在
   if (!fs.existsSync(skillsDir)) {
     // 创建目录
+    console.log(`[SkillLoader] Directory not found, creating: ${skillsDir}`);
     await fs.promises.mkdir(skillsDir, { recursive: true });
     return skills;
   }
   
   // 读取目录内容
   const entries = await fs.promises.readdir(skillsDir, { withFileTypes: true });
+  console.log(`[SkillLoader] Found ${entries.filter(e => e.isDirectory()).length} skill directories`);
   
   // 遍历子目录
   for (const entry of entries) {
@@ -251,10 +255,15 @@ export async function loadAllSkills(skillsDir: string): Promise<Skill[]> {
     const skillDir = pathModule.join(skillsDir, entry.name);
     const skillFile = pathModule.join(skillDir, 'SKILL.md');
     
+    console.log(`[SkillLoader] Loading: ${entry.name}/SKILL.md`);
+    
     // 加载技能文件
     const result = await loadSkill(skillFile);
     if (result.success && result.skill) {
+      console.log(`[SkillLoader] ✅ Loaded: ${result.skill.name} (triggers: ${result.skill.triggers.join(', ')})`);
       skills.push(result.skill);
+    } else {
+      console.log(`[SkillLoader] ❌ Failed: ${result.error}`);
     }
   }
   


### PR DESCRIPTION
## 修改内容

### 1. 注释掉事件日志
- 注释掉 `📨 收到事件` 日志，减少流式响应时的噪音

### 2. 增强 Skill 加载日志
- 显示加载目录和文件路径
- 显示每个 skill 的加载状态（✅/❌）
- 显示触发词列表

## 修改文件

- `src/core/agent/index.ts` (2 行变更)
- `src/core/skill/loader.ts` (9 行新增)

## 日志效果

```
[SkillLoader] Loading skills from: /root/.miniclaw/skills
[SkillLoader] Found 2 skill directories
[SkillLoader] Loading: weather/SKILL.md
[SkillLoader] ✅ Loaded: weather (triggers: 天气, 天气预报, 今天天气)
[SkillManager] Loaded 2 skills from /root/.miniclaw/skills
```

## 已禁用的日志

| 日志 | 状态 |
|------|------|
| 💭 推理 | ❌ 已禁用 |
| 📨 收到事件 | ❌ 已禁用 |
| 🔧 工具调用 | ✅ 保留 |
| ✅ 工具结果 | ✅ 保留 |