### PR TITLE
feat: 添加 SkillManager 初始化到主入口

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ import { MiniclawGateway } from './core/gateway/index.js';
 import { loadConfig, type Config, type AgentConfig } from './core/config.js';
 import { SubagentManager } from './core/subagent/manager.js';
 import { createSessionsSpawnTool, createSubagentsTool } from './core/subagent/tools.js';
+import { createSkillManager } from './core/skill/index.js';
 import { CliChannel } from './channels/cli.js';
 import { ApiChannel } from './channels/api.js';
 import { FeishuChannel } from './channels/feishu.js';
@@ -95,6 +96,13 @@ async function main() {
   const config = loadConfig();
   console.log(`模型: ${config.bailian.model}`);
   console.log(`API: ${config.bailian.baseUrl}`);
+
+  // 初始化 SkillManager
+  console.log('初始化 SkillManager...');
+  const skillManager = createSkillManager({ autoLoad: true });
+  // 等待异步加载完成
+  await new Promise(r => setTimeout(r, 100));
+  console.log(`已加载 ${skillManager.count()} 个技能: ${skillManager.getNames().join(', ') || '(无)'}`);
 
   // 创建 AgentRegistry
   const registry = new AgentRegistry(config, () => {


### PR DESCRIPTION
## 问题

之前代码没有在主入口初始化 SkillManager，导致启动时看不到 skill 加载日志。

## 修改内容

- 在 `main()` 中导入并初始化 SkillManager
- 添加启动日志显示加载的技能数量和名称
- 等待异步加载完成后再继续

## 启动效果

```
初始化 SkillManager...
[SkillLoader] Loading skills from: /root/.miniclaw/skills
[SkillLoader] Found 2 skill directories
[SkillLoader] Loading: weather/SKILL.md
[SkillLoader] ✅ Loaded: weather (triggers: 天气, 天气预报, ...)
[SkillManager] Loaded 2 skills from /root/.miniclaw/skills
已加载 2 个技能: test-skill, weather
```

## 修改文件

- `src/index.ts` (8 行新增)