### PR TITLE
feat(skill): integrate pi-coding-agent Skill API

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@mariozechner/pi-agent-core": "^0.57.1",
         "@mariozechner/pi-ai": "^0.57.1",
+        "@mariozechner/pi-coding-agent": "^0.65.2",
         "@mariozechner/pi-tui": "^0.57.1",
         "@types/express": "^5.0.6",
         "@types/node": "^25.4.0",
@@ -817,6 +818,16 @@
         "node": ">=18"
       }
     },
+    "node_modules/@borewit/text-codec": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmmirror.com/@borewit/text-codec/-/text-codec-0.2.2.tgz",
+      "integrity": "sha512-DDaRehssg1aNrH4+2hnj1B7vnUGEjU6OIlyRdkMd0aUdIUvKXrJfXsy8LVtXAy7DRvYVluWbMspsRhz2lcW0mQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/@cspotcode/source-map-support": {
       "version": "0.8.1",
       "resolved": "https://registry.npmmirror.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
@@ -1536,6 +1547,198 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@mariozechner/clipboard": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard/-/clipboard-0.3.2.tgz",
+      "integrity": "sha512-IHQpksNjo7EAtGuHFU+tbWDp5LarH3HU/8WiB9O70ZEoBPHOg0/6afwSLK0QyNMMmx4Bpi/zl6+DcBXe95nWYA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard-darwin-arm64": "0.3.2",
+        "@mariozechner/clipboard-darwin-universal": "0.3.2",
+        "@mariozechner/clipboard-darwin-x64": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-arm64-musl": "0.3.2",
+        "@mariozechner/clipboard-linux-riscv64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-gnu": "0.3.2",
+        "@mariozechner/clipboard-linux-x64-musl": "0.3.2",
+        "@mariozechner/clipboard-win32-arm64-msvc": "0.3.2",
+        "@mariozechner/clipboard-win32-x64-msvc": "0.3.2"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-arm64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-darwin-arm64/-/clipboard-darwin-arm64-0.3.2.tgz",
+      "integrity": "sha512-uBf6K7Je1ihsgvmWxA8UCGCeI+nbRVRXoarZdLjl6slz94Zs1tNKFZqx7aCI5O1i3e0B6ja82zZ06BWrl0MCVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-universal": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-darwin-universal/-/clipboard-darwin-universal-0.3.2.tgz",
+      "integrity": "sha512-mxSheKTW2U9LsBdXy0SdmdCAE5HqNS9QUmpNHLnfJ+SsbFKALjEZc5oRrVMXxGQSirDvYf5bjmRyT0QYYonnlg==",
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-darwin-x64": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-darwin-x64/-/clipboard-darwin-x64-0.3.2.tgz",
+      "integrity": "sha512-U1BcVEoidvwIp95+HJswSW+xr28EQiHR7rZjH6pn8Sja5yO4Yoe3yCN0Zm8Lo72BbSOK/fTSq0je7CJpaPCspg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-linux-arm64-gnu/-/clipboard-linux-arm64-gnu-0.3.2.tgz",
+      "integrity": "sha512-BsinwG3yWTIjdgNCxsFlip7LkfwPk+ruw/aFCXHUg/fb5XC/Ksp+YMQ7u0LUtiKzIv/7LMXgZInJQH6gxbAaqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-arm64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-linux-arm64-musl/-/clipboard-linux-arm64-musl-0.3.2.tgz",
+      "integrity": "sha512-0/Gi5Xq2V6goXBop19ePoHvXsmJD9SzFlO3S+d6+T2b+BlPcpOu3Oa0wTjl+cZrLAAEzA86aPNBI+VVAFDFPKw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-riscv64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-linux-riscv64-gnu/-/clipboard-linux-riscv64-gnu-0.3.2.tgz",
+      "integrity": "sha512-2AFFiXB24qf0zOZsxI1GJGb9wQGlOJyN6UwoXqmKS3dpQi/l6ix30IzDDA4c4ZcCcx4D+9HLYXhC1w7Sov8pXA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-gnu": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-linux-x64-gnu/-/clipboard-linux-x64-gnu-0.3.2.tgz",
+      "integrity": "sha512-v6fVnsn7WMGg73Dab8QMwyFce7tzGfgEixKgzLP8f1GJqkJZi5zO4k4FOHzSgUufgLil63gnxvMpjWkgfeQN7A==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-linux-x64-musl": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-linux-x64-musl/-/clipboard-linux-x64-musl-0.3.2.tgz",
+      "integrity": "sha512-xVUtnoMQ8v2JVyfJLKKXACA6avdnchdbBkTsZs8BgJQo29qwCp5NIHAUO8gbJ40iaEGToW5RlmVk2M9V0HsHEw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-arm64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-win32-arm64-msvc/-/clipboard-win32-arm64-msvc-0.3.2.tgz",
+      "integrity": "sha512-AEgg95TNi8TGgak2wSXZkXKCvAUTjWoU1Pqb0ON7JHrX78p616XUFNTJohtIon3e0w6k0pYPZeCuqRCza/Tqeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/clipboard-win32-x64-msvc": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/clipboard-win32-x64-msvc/-/clipboard-win32-x64-msvc-0.3.2.tgz",
+      "integrity": "sha512-tGRuYpZwDOD7HBrCpyRuhGnHHSCknELvqwKKUG4JSfSB7JIU7LKRh6zx6fMUOQd8uISK35TjFg5UcNih+vJhFA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@mariozechner/jiti": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/jiti/-/jiti-2.6.5.tgz",
+      "integrity": "sha512-faGUlTcXka5l7rv0lP3K3vGW/ejRuOS24RR2aSFWREUQqzjgdsuWNo/IiPqL3kWRGt6Ahl2+qcDAwtdeWeuGUw==",
+      "license": "MIT",
+      "dependencies": {
+        "std-env": "^3.10.0",
+        "yoctocolors": "^2.1.2"
+      },
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
     "node_modules/@mariozechner/pi-agent-core": {
       "version": "0.57.1",
       "resolved": "https://registry.npmmirror.com/@mariozechner/pi-agent-core/-/pi-agent-core-0.57.1.tgz",
@@ -1573,6 +1776,188 @@
       },
       "engines": {
         "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent": {
+      "version": "0.65.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/pi-coding-agent/-/pi-coding-agent-0.65.2.tgz",
+      "integrity": "sha512-/rpFzPQ+CishxrSwJHSSRZBQHHWy2K3Rbu/iV0HcMq/hl9cSI2ygpwjVTRbPW+NuP1tHxVV3AMxz69VLAs5Ztg==",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/jiti": "^2.6.2",
+        "@mariozechner/pi-agent-core": "^0.65.2",
+        "@mariozechner/pi-ai": "^0.65.2",
+        "@mariozechner/pi-tui": "^0.65.2",
+        "@silvia-odwyer/photon-node": "^0.3.4",
+        "ajv": "^8.17.1",
+        "chalk": "^5.5.0",
+        "cli-highlight": "^2.1.11",
+        "diff": "^8.0.2",
+        "extract-zip": "^2.0.1",
+        "file-type": "^21.1.1",
+        "glob": "^13.0.1",
+        "hosted-git-info": "^9.0.2",
+        "ignore": "^7.0.5",
+        "marked": "^15.0.12",
+        "minimatch": "^10.2.3",
+        "proper-lockfile": "^4.1.2",
+        "strip-ansi": "^7.1.0",
+        "undici": "^7.19.1",
+        "yaml": "^2.8.2"
+      },
+      "bin": {
+        "pi": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.6.0"
+      },
+      "optionalDependencies": {
+        "@mariozechner/clipboard": "^0.3.2"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-agent-core": {
+      "version": "0.65.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/pi-agent-core/-/pi-agent-core-0.65.2.tgz",
+      "integrity": "sha512-GYOrX5aRUpSDMPtKR174Tv72CWH92anqlRuiGn8PV05OowPAahT99JoxvZEP4fcKANBdHsyDfMMwFYpPhvPBUQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@mariozechner/pi-ai": "^0.65.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-ai": {
+      "version": "0.65.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/pi-ai/-/pi-ai-0.65.2.tgz",
+      "integrity": "sha512-XCbXncmh10Q89tvS0880Ms6pv3DTxFTEtanfVHEPXKQBi0FBYnrkAlOnP5VRU8vCfe18P1AMNsWCndsCBUqY7g==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": "^0.73.0",
+        "@aws-sdk/client-bedrock-runtime": "^3.983.0",
+        "@google/genai": "^1.40.0",
+        "@mistralai/mistralai": "1.14.1",
+        "@sinclair/typebox": "^0.34.41",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "chalk": "^5.6.2",
+        "openai": "6.26.0",
+        "partial-json": "^0.1.7",
+        "proxy-agent": "^6.5.0",
+        "undici": "^7.19.1",
+        "zod-to-json-schema": "^3.24.6"
+      },
+      "bin": {
+        "pi-ai": "dist/cli.js"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/@mariozechner/pi-tui": {
+      "version": "0.65.2",
+      "resolved": "https://registry.npmmirror.com/@mariozechner/pi-tui/-/pi-tui-0.65.2.tgz",
+      "integrity": "sha512-LBPbIBASjCF4QLrc/dwmPdBzVMsbkDhzmBIAFgglX5rZBnGRppB7ekSA+1kb5pdxDpDn8IbxJX+bl7ZaeqZqxw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime-types": "^2.1.4",
+        "chalk": "^5.5.0",
+        "get-east-asian-width": "^1.3.0",
+        "marked": "^15.0.12",
+        "mime-types": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "optionalDependencies": {
+        "koffi": "^2.9.0"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmmirror.com/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmmirror.com/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/diff": {
+      "version": "8.0.4",
+      "resolved": "https://registry.npmmirror.com/diff/-/diff-8.0.4.tgz",
+      "integrity": "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/glob": {
+      "version": "13.0.6",
+      "resolved": "https://registry.npmmirror.com/glob/-/glob-13.0.6.tgz",
+      "integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "minimatch": "^10.2.2",
+        "minipass": "^7.1.3",
+        "path-scurry": "^2.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/lru-cache": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.3.2.tgz",
+      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmmirror.com/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@mariozechner/pi-coding-agent/node_modules/path-scurry": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmmirror.com/path-scurry/-/path-scurry-2.0.2.tgz",
+      "integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "lru-cache": "^11.0.0",
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/@mariozechner/pi-tui": {
@@ -2027,6 +2412,12 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@silvia-odwyer/photon-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmmirror.com/@silvia-odwyer/photon-node/-/photon-node-0.3.4.tgz",
+      "integrity": "sha512-bnly4BKB3KDTFxrUIcgCLbaeVVS8lrAkri1pEzskpmxu9MdfGQTy8b8EgcD83ywD3RPMsIulY8xJH5Awa+t9fA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.34.48",
@@ -2697,6 +3088,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmmirror.com/@tokenizer/inflate/-/inflate-0.4.1.tgz",
+      "integrity": "sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "token-types": "^6.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmmirror.com/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
+    },
     "node_modules/@tootallnate/quickjs-emscripten": {
       "version": "0.23.0",
       "resolved": "https://registry.npmmirror.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz",
@@ -2884,6 +3298,16 @@
       "resolved": "https://registry.npmmirror.com/@types/ws/-/ws-8.18.1.tgz",
       "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
       "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/yauzl": {
+      "version": "2.10.3",
+      "resolved": "https://registry.npmmirror.com/@types/yauzl/-/yauzl-2.10.3.tgz",
+      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
+      "license": "MIT",
+      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -3417,6 +3841,12 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/any-promise": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmmirror.com/any-promise/-/any-promise-1.3.0.tgz",
+      "integrity": "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==",
+      "license": "MIT"
+    },
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmmirror.com/arg/-/arg-4.1.3.tgz",
@@ -3550,6 +3980,15 @@
         "balanced-match": "^1.0.0"
       }
     },
+    "node_modules/buffer-crc32": {
+      "version": "0.2.13",
+      "resolved": "https://registry.npmmirror.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/buffer-equal-constant-time": {
       "version": "1.0.1",
       "resolved": "https://registry.npmmirror.com/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
@@ -3614,6 +4053,142 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmmirror.com/cli-highlight/-/cli-highlight-2.1.11.tgz",
+      "integrity": "sha512-9KDcoEVwyUXrjcJNvHD0NFc/hiwe/WPVYIleQh2O1N2Zro5gWJZ/K+3DGn8w8P/F6FxOgzyC5bxDyHIgCSPhGg==",
+      "license": "ISC",
+      "dependencies": {
+        "chalk": "^4.0.0",
+        "highlight.js": "^10.7.1",
+        "mz": "^2.4.0",
+        "parse5": "^5.1.1",
+        "parse5-htmlparser2-tree-adapter": "^6.0.0",
+        "yargs": "^16.0.0"
+      },
+      "bin": {
+        "highlight": "bin/highlight"
+      },
+      "engines": {
+        "node": ">=8.0.0",
+        "npm": ">=5.0.0"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cli-highlight/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmmirror.com/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmmirror.com/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/cliui/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/cliui/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cliui/node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmmirror.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
     "node_modules/color-convert": {
@@ -3840,6 +4415,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmmirror.com/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
+      }
+    },
     "node_modules/engine.io": {
       "version": "6.6.6",
       "resolved": "https://registry.npmmirror.com/engine.io/-/engine.io-6.6.6.tgz",
@@ -4011,6 +4595,15 @@
         "@esbuild/win32-arm64": "0.27.3",
         "@esbuild/win32-ia32": "0.27.3",
         "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmmirror.com/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/escape-html": {
@@ -4409,6 +5002,26 @@
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
     },
+    "node_modules/extract-zip": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmmirror.com/extract-zip/-/extract-zip-2.0.1.tgz",
+      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "debug": "^4.1.1",
+        "get-stream": "^5.1.0",
+        "yauzl": "^2.10.0"
+      },
+      "bin": {
+        "extract-zip": "cli.js"
+      },
+      "engines": {
+        "node": ">= 10.17.0"
+      },
+      "optionalDependencies": {
+        "@types/yauzl": "^2.9.1"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmmirror.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -4476,6 +5089,15 @@
         "fxparser": "src/cli/cli.js"
       }
     },
+    "node_modules/fd-slicer": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmmirror.com/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
+      "license": "MIT",
+      "dependencies": {
+        "pend": "~1.2.0"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmmirror.com/fdir/-/fdir-6.5.0.tgz",
@@ -4528,6 +5150,24 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/file-type": {
+      "version": "21.3.4",
+      "resolved": "https://registry.npmmirror.com/file-type/-/file-type-21.3.4.tgz",
+      "integrity": "sha512-Ievi/yy8DS3ygGvT47PjSfdFoX+2isQueoYP1cntFW1JLYAuS4GD7NUPGg4zv2iZfV52uDyk5w5Z0TdpRS6Q1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.4.1",
+        "strtok3": "^10.3.4",
+        "token-types": "^6.1.1",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
       }
     },
     "node_modules/finalhandler": {
@@ -4688,6 +5328,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmmirror.com/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
     "node_modules/get-east-asian-width": {
       "version": "1.5.0",
       "resolved": "https://registry.npmmirror.com/get-east-asian-width/-/get-east-asian-width-1.5.0.tgz",
@@ -4735,6 +5384,21 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/get-stream": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmmirror.com/get-stream/-/get-stream-5.2.0.tgz",
+      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
+      "license": "MIT",
+      "dependencies": {
+        "pump": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-tsconfig": {
@@ -4844,11 +5508,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmmirror.com/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4876,6 +5545,36 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/highlight.js": {
+      "version": "10.7.3",
+      "resolved": "https://registry.npmmirror.com/highlight.js/-/highlight.js-10.7.3.tgz",
+      "integrity": "sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/hosted-git-info": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmmirror.com/hosted-git-info/-/hosted-git-info-9.0.2.tgz",
+      "integrity": "sha512-M422h7o/BR3rmCQ8UHi7cyyMqKltdP9Uo+J2fXK+RSAY+wTcKOIRyhTuKv4qn+DJf3g+PL890AzId5KZpX+CBg==",
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^11.1.0"
+      },
+      "engines": {
+        "node": "^20.17.0 || >=22.9.0"
+      }
+    },
+    "node_modules/hosted-git-info/node_modules/lru-cache": {
+      "version": "11.3.2",
+      "resolved": "https://registry.npmmirror.com/lru-cache/-/lru-cache-11.3.2.tgz",
+      "integrity": "sha512-wgWa6FWQ3QRRJbIjbsldRJZxdxYngT/dO0I5Ynmlnin8qy7tC6xYzbcJjtN4wHLXtkbVwHzk0C+OejVw1XM+DQ==",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/html-escaper": {
@@ -4947,11 +5646,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmmirror.com/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "7.0.5",
       "resolved": "https://registry.npmmirror.com/ignore/-/ignore-7.0.5.tgz",
       "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 4"
@@ -5367,6 +6085,17 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/mz": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmmirror.com/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0",
+        "object-assign": "^4.0.1",
+        "thenify-all": "^1.0.0"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmmirror.com/nanoid/-/nanoid-3.3.11.tgz",
@@ -5624,6 +6353,27 @@
       "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/parse5": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-5.1.1.tgz",
+      "integrity": "sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==",
+      "license": "MIT"
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-6.0.1.tgz",
+      "integrity": "sha512-qPuWvbLgvDGilKc5BoicRovlT4MtYT6JfJyBOMDsKoiT+GiuP5qyrPCnR9HcPECIJJmZh5jRndyNThnhhb/vlA==",
+      "license": "MIT",
+      "dependencies": {
+        "parse5": "^6.0.1"
+      }
+    },
+    "node_modules/parse5-htmlparser2-tree-adapter/node_modules/parse5": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/parse5/-/parse5-6.0.1.tgz",
+      "integrity": "sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==",
+      "license": "MIT"
+    },
     "node_modules/parseurl": {
       "version": "1.3.3",
       "resolved": "https://registry.npmmirror.com/parseurl/-/parseurl-1.3.3.tgz",
@@ -5695,6 +6445,12 @@
       "resolved": "https://registry.npmmirror.com/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pend": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmmirror.com/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
       "license": "MIT"
     },
     "node_modules/picocolors": {
@@ -5772,6 +6528,32 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/proper-lockfile": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmmirror.com/proper-lockfile/-/proper-lockfile-4.1.2.tgz",
+      "integrity": "sha512-TjNPblN4BwAWMXU8s9AEz4JmQxnD1NNL7bNOY/AKUzyamc379FWASUhc/K1pL2noVb+XmZKLL68cjzLsiOAMaA==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "retry": "^0.12.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmmirror.com/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/proper-lockfile/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmmirror.com/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/protobufjs": {
       "version": "7.5.4",
       "resolved": "https://registry.npmmirror.com/protobufjs/-/protobufjs-7.5.4.tgz",
@@ -5834,6 +6616,16 @@
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
     },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmmirror.com/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmmirror.com/punycode/-/punycode-2.3.1.tgz",
@@ -5881,6 +6673,15 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/require-from-string": {
@@ -6372,7 +7173,6 @@
       "version": "3.10.0",
       "resolved": "https://registry.npmmirror.com/std-env/-/std-env-3.10.0.tgz",
       "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/string-width": {
@@ -6483,17 +7283,53 @@
       ],
       "license": "MIT"
     },
+    "node_modules/strtok3": {
+      "version": "10.3.5",
+      "resolved": "https://registry.npmmirror.com/strtok3/-/strtok3-10.3.5.tgz",
+      "integrity": "sha512-ki4hZQfh5rX0QDLLkOCj+h+CVNkqmp/CMf8v8kZpkNVK6jGQooMytqzLZYUVYIZcFZ6yDB70EfD8POcFXiF5oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmmirror.com/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/thenify": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmmirror.com/thenify/-/thenify-3.3.1.tgz",
+      "integrity": "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==",
+      "license": "MIT",
+      "dependencies": {
+        "any-promise": "^1.0.0"
+      }
+    },
+    "node_modules/thenify-all": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmmirror.com/thenify-all/-/thenify-all-1.6.0.tgz",
+      "integrity": "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==",
+      "license": "MIT",
+      "dependencies": {
+        "thenify": ">= 3.1.0 < 4"
+      },
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/tinybench": {
@@ -6547,6 +7383,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmmirror.com/token-types/-/token-types-6.1.2.tgz",
+      "integrity": "sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@borewit/text-codec": "^0.2.1",
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/ts-algebra": {
@@ -6677,6 +7531,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmmirror.com/uint8array-extras/-/uint8array-extras-1.5.0.tgz",
+      "integrity": "sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undici": {
@@ -7051,6 +7917,108 @@
         }
       }
     },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmmirror.com/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "2.8.3",
+      "resolved": "https://registry.npmmirror.com/yaml/-/yaml-2.8.3.tgz",
+      "integrity": "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmmirror.com/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmmirror.com/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmmirror.com/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmmirror.com/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/yargs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmmirror.com/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yargs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmmirror.com/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/yauzl": {
+      "version": "2.10.0",
+      "resolved": "https://registry.npmmirror.com/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-crc32": "~0.2.3",
+        "fd-slicer": "~1.1.0"
+      }
+    },
     "node_modules/yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmmirror.com/yn/-/yn-3.1.1.tgz",
@@ -7069,6 +8037,18 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/yoctocolors": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmmirror.com/yoctocolors/-/yoctocolors-2.1.2.tgz",
+      "integrity": "sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@mariozechner/pi-agent-core": "^0.57.1",
     "@mariozechner/pi-ai": "^0.57.1",
+    "@mariozechner/pi-coding-agent": "^0.65.2",
     "@mariozechner/pi-tui": "^0.57.1",
     "@types/express": "^5.0.6",
     "@types/node": "^25.4.0",

--- a/specs/010-pi-skill-integration/checklists/requirements.md
+++ b/specs/010-pi-skill-integration/checklists/requirements.md
@@ -1,0 +1,37 @@
+# Specification Quality Checklist: pi-coding-agent Skill API Integration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-07
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass validation
+- Specification is ready for `/speckit.clarify` or `/speckit.plan`
+- The spec describes WHAT the system should do without specifying HOW (implementation)
+- Success criteria are measurable and user-focused

--- a/specs/010-pi-skill-integration/data-model.md
+++ b/specs/010-pi-skill-integration/data-model.md
@@ -1,0 +1,153 @@
+# Data Model: pi-coding-agent Skill API Integration
+
+**Feature**: 010-pi-skill-integration
+**Date**: 2026-04-07
+
+## Core Entities
+
+### PiSkillManager
+
+Wrapper for pi-coding-agent Skill APIs. Manages skill loading, matching, and prompt formatting.
+
+```typescript
+interface PiSkillManagerOptions {
+  /** Skills directory path */
+  skillsDir?: string;
+  /** Source identifier for loaded skills */
+  source?: string;
+  /** Enable/disable skill system */
+  enabled?: boolean;
+}
+
+class PiSkillManager {
+  // Properties
+  private skills: Skill[];           // Loaded skills from pi-coding-agent
+  private matcher: SkillMatcher;     // Existing matcher for matching logic
+  private skillsDir: string;         // Configured directory
+  private enabled: boolean;          // Is skill system enabled
+
+  // Methods
+  load(): void;                      // Load skills from directory
+  match(input: string): Skill | null; // Match user input to skill
+  getPrompt(skill: Skill): string;   // Get formatted prompt for skill
+  count(): number;                   // Number of loaded skills
+  getNames(): string[];              // List of skill names
+  getAll(): Skill[];                 // All loaded skills
+  getStatus(): SkillSystemStatus;    // System status
+}
+```
+
+### Skill (pi-coding-agent type)
+
+```typescript
+// From @mariozechner/pi-coding-agent
+interface Skill {
+  name: string;           // Skill name
+  description: string;    // Skill description (contains triggers)
+  filePath: string;       // Absolute path to skill file
+  baseDir: string;        // Base directory for skill
+  sourceInfo: SourceInfo; // Source metadata
+  disableModelInvocation: boolean; // If true, exclude from auto-prompt
+}
+```
+
+### SkillMatchResult
+
+Result from matching user input to skills.
+
+```typescript
+interface SkillMatchResult {
+  skill: Skill;           // Matched skill
+  matchType: 'trigger' | 'description'; // How it matched
+  matchedKeyword: string; // The keyword that triggered match
+}
+```
+
+### SkillSystemStatus
+
+Status information for the skill system.
+
+```typescript
+interface SkillSystemStatus {
+  skillCount: number;     // Number of loaded skills
+  skillNames: string[];   // Names of loaded skills
+  skillsDir: string;      // Directory path
+  enabled: boolean;       // Is system enabled
+  diagnostics: ResourceDiagnostic[]; // Any loading errors
+}
+```
+
+---
+
+## Relationships
+
+```
+PiSkillManager
+    │
+    ├── uses ──► loadSkillsFromDir (pi-coding-agent)
+    │
+    ├── uses ──► formatSkillsForPrompt (pi-coding-agent)
+    │
+    ├── uses ──► SkillMatcher (existing)
+    │               │
+    │               └──► triggers: string[] (from Skill.description)
+    │
+    └── produces ──► SkillMatchResult
+                      │
+                      └──► Skill
+```
+
+---
+
+## State Transitions
+
+### Skill Loading
+
+```
+[Uninitialized] ──► load() ──► [Loaded]
+                      │
+                      ├── skills populated
+                      ├── matcher initialized
+                      └── diagnostics logged
+```
+
+### Skill Matching
+
+```
+[Loaded] ──► match(input) ──► [Matched] or [NoMatch]
+                │
+                ├── Matched → getPrompt() → inject into Agent
+                └── NoMatch → normal Agent operation
+```
+
+---
+
+## Validation Rules
+
+| Field | Rule |
+|-------|------|
+| `skillsDir` | Must exist if configured, warn if missing |
+| `Skill.name` | Required, non-empty |
+| `Skill.description` | Required, non-empty |
+| `disableModelInvocation` | Boolean, default false |
+
+---
+
+## Configuration Extension
+
+```typescript
+// Add to src/core/config.ts Config interface
+interface Config {
+  // ... existing fields
+  skills?: {
+    /** Skills directory path, default ~/.miniclaw/skills */
+    dir?: string;
+    /** Enable skill system, default true */
+    enabled?: boolean;
+  }
+}
+```
+
+Environment variables:
+- `MINICLAW_SKILLS_DIR` - Custom skills directory
+- `MINICLAW_SKILLS_ENABLED` - Enable/disable (true/false)

--- a/specs/010-pi-skill-integration/plan.md
+++ b/specs/010-pi-skill-integration/plan.md
@@ -1,0 +1,151 @@
+# Implementation Plan: pi-coding-agent Skill API Integration
+
+**Branch**: `010-pi-skill-integration` | **Date**: 2026-04-07 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/010-pi-skill-integration/spec.md`
+
+## Summary
+
+Integrate @mariozechner/pi-coding-agent's Skill API into Miniclaw, replacing the existing custom skill system. This involves:
+1. Creating a new SkillManager wrapper using pi-coding-agent's `loadSkillsFromDir` and `formatSkillsForPrompt` APIs
+2. Updating `src/index.ts` to initialize the new SkillManager at startup
+3. Enhancing `MiniclawAgent` to inject skill prompts into system prompt when matched
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x / Node.js 18+
+**Primary Dependencies**: @mariozechner/pi-agent-core (^0.57.1), @mariozechner/pi-coding-agent (^0.65.2)
+**Storage**: N/A (skills loaded from markdown files in filesystem)
+**Testing**: Vitest (^4.0.18)
+**Target Platform**: Linux server (Node.js runtime)
+**Project Type**: CLI/web-service AI assistant framework
+**Performance Goals**: Startup <2s with 50+ skills, matching <100ms per input
+**Constraints**: Must maintain backward compatibility when no skills configured
+**Scale/Scope**: Personal assistant, single user, ~10-50 skills typical
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+**Status**: No constitution defined (template file only). Proceeding without gate constraints.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/010-pi-skill-integration/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/           # Phase 1 output (N/A - internal integration)
+└── tasks.md             # Phase 2 output (/speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── core/
+│   ├── agent/
+│   │   └── index.ts         # MiniclawAgent - needs skill integration
+│   │   └── registry.ts      # AgentRegistry
+│   ├── gateway/
+│   │   └── index.ts         # MiniclawGateway
+│   ├── skill/
+│   │   ├── pi-manager.ts    # NEW: pi SkillManager wrapper
+│   │   ├── index.ts         # Existing exports (to be updated)
+│   │   ├── types.ts         # Existing types
+│   │   └── matcher.ts       # Existing matcher
+│   │   └── loader.ts        # Existing loader
+│   │   └── manager.ts       # Existing manager (to be deprecated)
+│   └── config.ts            # Configuration
+├── index.ts                 # Main entry - needs SkillManager init
+└── tools/
+    └── index.ts             # Built-in tools
+
+tests/
+├── unit/
+│   └── skill-manager.test.ts  # Unit tests for new pi-manager
+└── integration/
+    └── skill-flow.test.ts     # Integration tests for skill flow
+```
+
+**Structure Decision**: Single project structure. New file `pi-manager.ts` added to existing `src/core/skill/` directory.
+
+## Complexity Tracking
+
+No complexity violations - straightforward integration using existing APIs.
+
+---
+
+## Phase 0: Research
+
+### Research Tasks
+
+1. **pi-coding-agent Skill API Usage**
+   - API: `loadSkillsFromDir(options)` - synchronous loading from directory
+   - API: `formatSkillsForPrompt(skills)` - XML format per Agent Skills standard
+   - Types: `Skill`, `SkillFrontmatter`, `LoadSkillsResult`, `LoadSkillsFromDirOptions`
+
+2. **Skill Discovery Rules (from pi-coding-agent)**
+   - If directory contains SKILL.md, treat as skill root (no recursion)
+   - Otherwise, load direct .md children in root
+   - Recurse into subdirectories to find SKILL.md
+
+3. **Matching Strategy**
+   - Existing custom matcher in `src/core/skill/matcher.ts` works on triggers extracted from description
+   - pi-coding-agent does NOT provide matching - only loading and formatting
+   - Need to keep existing matcher or implement simple keyword matching
+
+4. **Backward Compatibility**
+   - Current skill system is commented out in `src/index.ts` and `src/core/agent/index.ts`
+   - Agent must work normally when no SkillManager configured
+
+### Research Output
+
+**Decision**: Use pi-coding-agent for loading/formatting, keep existing matcher for matching logic.
+
+**Rationale**: pi-coding-agent provides standardized skill loading and prompt formatting, but does not include matching functionality. The existing matcher in `src/core/skill/matcher.ts` can be reused with minor adaptations.
+
+**Alternatives Considered**:
+- Implement new matcher from scratch: Rejected - existing matcher is well-tested
+- Use pi-coding-agent AgentSession directly: Rejected - too invasive, would change entire architecture
+
+---
+
+## Phase 1: Design
+
+### Data Model
+
+See `data-model.md` for entity definitions.
+
+Key entities:
+- **PiSkillManager**: Wrapper for pi-coding-agent Skill APIs
+- **SkillMatchResult**: Existing type, reused for matching results
+
+### Contracts
+
+**N/A** - This is an internal integration, no external API contracts changed.
+
+### Integration Points
+
+1. **src/core/skill/pi-manager.ts** (NEW)
+   - Imports from `@mariozechner/pi-coding-agent`
+   - `loadSkillsFromDir()` → synchronous skill loading
+   - `formatSkillsForPrompt()` → prompt formatting
+   - Exposes: `match(input)`, `getPrompt(skillName)`, `count()`, `getNames()`
+
+2. **src/index.ts**
+   - Initialize PiSkillManager at startup
+   - Pass to AgentRegistry/createAgentFactory
+   - Log loaded skill count
+
+3. **src/core/agent/index.ts**
+   - Accept SkillManager in constructor options
+   - Inject skill prompt before `agent.prompt()`
+   - Restore original system prompt after processing
+
+### Quickstart
+
+See `quickstart.md` for developer setup guide.

--- a/specs/010-pi-skill-integration/quickstart.md
+++ b/specs/010-pi-skill-integration/quickstart.md
@@ -1,0 +1,174 @@
+# Quickstart: pi-coding-agent Skill API Integration
+
+**Feature**: 010-pi-skill-integration
+**Date**: 2026-04-07
+
+## Prerequisites
+
+- Node.js 18+
+- TypeScript 5.x
+- Vitest for testing
+
+## Setup
+
+### 1. Dependencies
+
+Already installed in package.json:
+```json
+"@mariozechner/pi-coding-agent": "^0.65.2"
+```
+
+### 2. Skills Directory
+
+Create skills directory:
+```bash
+mkdir -p ~/.miniclaw/skills
+```
+
+### 3. Create a Test Skill
+
+Create a skill file:
+```bash
+cat > ~/.miniclaw/skills/test.md << 'EOF'
+---
+name: test-skill
+description: A test skill for testing [test] [testing]
+---
+
+## Test Skill
+
+This is a test skill for verifying skill integration.
+
+When this skill is matched, the agent will follow these instructions.
+EOF
+```
+
+## Running
+
+### CLI Mode (with skills)
+
+```bash
+npm run debug:cli
+```
+
+Expected startup log:
+```
+Miniclaw 启动中...
+
+模型: qwen-plus
+API: https://...
+初始化 SkillManager...
+已加载 1 个技能: test-skill
+...
+```
+
+### Testing Skill Matching
+
+Send a message containing trigger words:
+```
+> test the skill system
+```
+
+Expected log showing skill match:
+```
+[main] 🎯 匹配到技能: test-skill
+[main] 📋 已注入技能 prompt (xxx 字符)
+```
+
+## Testing
+
+### Unit Tests
+
+```bash
+# Test pi-manager
+npm run test -- tests/unit/skill-pi-manager.test.ts
+```
+
+### Integration Tests
+
+```bash
+# Test skill flow with Agent
+npm run test -- tests/integration/skill-flow.test.ts
+```
+
+## Configuration
+
+### Environment Variables
+
+```bash
+# Custom skills directory
+MINICLAW_SKILLS_DIR=/path/to/skills
+
+# Disable skills
+MINICLAW_SKILLS_ENABLED=false
+```
+
+### Config File (config.yaml)
+
+```yaml
+skills:
+  dir: ~/.miniclaw/skills
+  enabled: true
+```
+
+## Troubleshooting
+
+### Skills not loading
+
+Check directory exists:
+```bash
+ls -la ~/.miniclaw/skills
+```
+
+Check file format (must have frontmatter):
+```bash
+head -5 ~/.miniclaw/skills/*.md
+```
+
+Expected:
+```
+---
+name: skill-name
+description: Skill description [trigger1] [trigger2]
+---
+```
+
+### Skills not matching
+
+Check trigger words in description:
+- Triggers are words wrapped in `[]` brackets
+- Example: `description: Git operations skill [git] [commit] [push]`
+
+### Agent behavior unchanged
+
+Check skill system enabled:
+```bash
+# Should show skill loading in startup logs
+npm run debug:cli | grep -i skill
+```
+
+## Development Notes
+
+### Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/core/skill/pi-manager.ts` | NEW - Create SkillManager wrapper |
+| `src/index.ts` | Add SkillManager initialization |
+| `src/core/agent/index.ts` | Add skill injection in chat/streamChat |
+| `src/core/config.ts` | Add skills config options |
+
+### Key Integration Points
+
+1. **Startup** (`src/index.ts`)
+   - Create PiSkillManager
+   - Log loaded skill count
+
+2. **Agent Construction** (`src/core/agent/index.ts`)
+   - Accept SkillManager in options
+   - Store for later use
+
+3. **Chat Processing** (`src/core/agent/index.ts::chat()`)
+   - Match input against skills
+   - Inject matched skill prompt
+   - Restore after processing

--- a/specs/010-pi-skill-integration/research.md
+++ b/specs/010-pi-skill-integration/research.md
@@ -1,0 +1,192 @@
+# Research: pi-coding-agent Skill API Integration
+
+**Feature**: 010-pi-skill-integration
+**Date**: 2026-04-07
+
+## 1. pi-coding-agent Skill API
+
+### Key APIs
+
+```typescript
+// From @mariozechner/pi-coding-agent/dist/core/skills.d.ts
+
+interface LoadSkillsFromDirOptions {
+  dir: string;        // Directory to scan for skills
+  source: string;     // Source identifier for these skills
+}
+
+interface LoadSkillsResult {
+  skills: Skill[];
+  diagnostics: ResourceDiagnostic[];
+}
+
+interface Skill {
+  name: string;
+  description: string;
+  filePath: string;
+  baseDir: string;
+  sourceInfo: SourceInfo;
+  disableModelInvocation: boolean;
+}
+
+interface SkillFrontmatter {
+  name?: string;
+  description?: string;
+  "disable-model-invocation"?: boolean;
+  [key: string]: unknown;
+}
+
+// Main functions
+function loadSkillsFromDir(options: LoadSkillsFromDirOptions): LoadSkillsResult;
+function formatSkillsForPrompt(skills: Skill[]): string;
+```
+
+### Usage Pattern
+
+```typescript
+import { loadSkillsFromDir, formatSkillsForPrompt } from '@mariozechner/pi-coding-agent';
+
+// Load skills from directory
+const result = loadSkillsFromDir({
+  dir: '/path/to/skills',
+  source: 'miniclaw'
+});
+
+// Access loaded skills
+console.log(`Loaded ${result.skills.length} skills`);
+
+// Format for system prompt (XML format per Agent Skills standard)
+const promptText = formatSkillsForPrompt(result.skills);
+```
+
+### Discovery Rules
+
+Per pi-coding-agent implementation:
+1. If a directory contains `SKILL.md`, treat it as a skill root and do not recurse further
+2. Otherwise, load direct `.md` children in the root
+3. Recurse into subdirectories to find `SKILL.md`
+
+### formatSkillsForPrompt Output Format
+
+Uses XML format per Agent Skills standard (https://agentskills.io/integrate-skills):
+
+```xml
+<skill name="skill-name">
+<description>Skill description</description>
+...
+</skill>
+```
+
+Skills with `disableModelInvocation=true` are excluded from prompt.
+
+---
+
+## 2. Matching Strategy
+
+### Problem
+
+pi-coding-agent provides loading and formatting but NOT matching functionality.
+
+### Options Evaluated
+
+| Option | Pros | Cons | Decision |
+|--------|------|------|----------|
+| Keep existing matcher | Well-tested, trigger-based matching | Uses different Skill type | **Selected** |
+| Implement keyword matching | Simple | New code, needs testing | Rejected |
+| Use description substring | Fast | Less precise | Rejected |
+
+### Decision
+
+Keep existing matcher from `src/core/skill/matcher.ts`, adapt to work with pi Skill type.
+
+### Implementation
+
+Create adapter that:
+1. Converts pi Skill to local Skill format for matching
+2. Uses existing `SkillMatcher.findBestMatch()` logic
+3. Returns matched skill for prompt injection
+
+---
+
+## 3. Backward Compatibility
+
+### Current State
+
+- Skill system commented out in `src/index.ts` (lines 104-110)
+- Skill system commented out in `src/core/agent/index.ts` (lines 41-42, 71, 574-595, 755-776)
+
+### Requirements (per spec FR-009)
+
+- Agent must work normally when no SkillManager configured
+- No skill prompt injection if SkillManager is undefined
+
+### Implementation
+
+```typescript
+// In MiniclawAgent constructor
+constructor(config: Config, options?: MiniclawAgentOptions) {
+  // ...
+  this.skillManager = options?.skillManager;  // Optional
+}
+
+// In chat/streamChat
+if (this.skillManager) {
+  const matched = this.skillManager.match(input);
+  if (matched) {
+    // Inject prompt
+  }
+}
+// else: no skill injection, normal operation
+```
+
+---
+
+## 4. Skill Directory Configuration
+
+### Default Location
+
+Following pi-coding-agent convention:
+- Global: `~/.pi/agent/skills/`
+- Local: `<project>/.skills/`
+
+### Miniclaw Configuration
+
+Add to Config:
+```typescript
+interface Config {
+  // ... existing fields
+  skills?: {
+    dir?: string;      // Custom skills directory
+    enabled?: boolean; // Enable/disable skill system
+  }
+}
+```
+
+Default: `~/.miniclaw/skills/` (consistent with existing Miniclaw convention)
+
+---
+
+## 5. Error Handling
+
+### Loading Errors
+
+- `loadSkillsFromDir` returns diagnostics for invalid files
+- Log errors but continue loading valid skills
+- Startup continues even if skill loading fails
+
+### Matching Errors
+
+- No match → return null, normal operation
+- Match but no prompt → empty string, no injection
+
+---
+
+## Summary
+
+| Decision | Rationale |
+|----------|-----------|
+| Use `loadSkillsFromDir` + `formatSkillsForPrompt` | Standardized loading/formatting |
+| Keep existing matcher | Well-tested, trigger-based matching |
+| Optional SkillManager injection | Backward compatibility |
+| Default directory `~/.miniclaw/skills/` | Consistent with Miniclaw convention |
+| Graceful error handling | Robust startup behavior |

--- a/specs/010-pi-skill-integration/spec.md
+++ b/specs/010-pi-skill-integration/spec.md
@@ -1,0 +1,93 @@
+# Feature Specification: pi-coding-agent Skill API Integration
+
+**Feature Branch**: `010-pi-skill-integration`
+**Created**: 2026-04-07
+**Status**: Draft
+**Input**: User description: "为 miniclaw 项目集成 @mariozechner/pi-coding-agent 的 Skill API。背景：miniclaw 项目原有的 skill 系统已被注释掉，需要使用 pi-coding-agent 的 Skill API 重新实现。需求：1. 创建 src/core/skill/pi-manager.ts，使用 pi-coding-agent API 实现 SkillManager；2. 改造 src/index.ts，使用新的 pi SkillManager；3. 改造 src/core/agent/index.ts，在 Agent 构造时注入 skill prompt。"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Skill Loading at Startup (Priority: P1)
+
+When the Miniclaw application starts, the system automatically loads skill definitions from the configured skills directory and makes them available to all Agent instances. Users can see which skills are loaded through startup logs.
+
+**Why this priority**: This is the foundation for all skill functionality. Without loading skills, no skill matching or prompt injection can occur.
+
+**Independent Test**: Can be fully tested by starting the application in CLI mode and verifying that startup logs show the number of skills loaded.
+
+**Acceptance Scenarios**:
+
+1. **Given** a skills directory exists with valid skill files, **When** the application starts, **Then** the startup logs display the count of successfully loaded skills
+2. **Given** no skills directory exists, **When** the application starts, **Then** the system gracefully handles this with a warning message and continues normal operation
+3. **Given** a skills directory contains invalid skill files, **When** the application starts, **Then** the system reports errors for those specific files without crashing
+
+---
+
+### User Story 2 - Skill Matching During Conversation (Priority: P2)
+
+During a conversation, when a user sends a message, the system automatically identifies which skill (if any) matches the user's intent based on triggers defined in the skill metadata. The matched skill's prompt content is injected into the Agent's system prompt.
+
+**Why this priority**: This enables the core value proposition - dynamically enhancing Agent capabilities based on user intent.
+
+**Independent Test**: Can be tested by sending specific trigger phrases in CLI mode and observing log output indicating skill matching.
+
+**Acceptance Scenarios**:
+
+1. **Given** a skill "git-commit" with trigger "commit", **When** the user sends "commit the current changes", **Then** the Agent logs show skill "git-commit" was matched
+2. **Given** multiple skills could match the user input, **When** the user sends a message, **Then** the system selects the best matching skill based on defined priority rules
+3. **Given** no skill matches the user input, **When** the user sends a message, **Then** the Agent processes the message normally without skill prompt injection
+
+---
+
+### User Story 3 - Skill Prompt Injection into Agent (Priority: P3)
+
+When a skill is matched, its prompt content is formatted using the pi-coding-agent API and appended to the Agent's system prompt, providing context-specific guidance for the current request. After processing, the original system prompt is restored.
+
+**Why this priority**: This enables the actual enhancement of Agent behavior through skill prompts while maintaining clean state management.
+
+**Independent Test**: Can be tested by matching a skill and verifying the Agent's response follows the skill's guidance.
+
+**Acceptance Scenarios**:
+
+1. **Given** a skill is matched, **When** the Agent processes the request, **Then** the skill prompt is visible in the Agent's context logs as part of the system prompt
+2. **Given** a skill with detailed instructions is matched, **When** the Agent generates a response, **Then** the response content reflects the skill's guidance
+3. **Given** a skill was matched and processing completes, **When** the next request arrives, **Then** the Agent's system prompt has returned to its original state
+
+---
+
+### Edge Cases
+
+- What happens when the skills directory path is not configured? System uses a default directory or gracefully continues without skills.
+- How does the system handle a skill file that is syntactically valid but has empty trigger definitions? The skill is loaded but never matches.
+- What happens when two skills have identical trigger patterns? The first loaded skill or the one with higher priority wins.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST load skill definitions from a specified directory using `loadSkillsFromDir` API from pi-coding-agent
+- **FR-002**: System MUST format matched skills into prompt strings using `formatSkillsForPrompt` API from pi-coding-agent
+- **FR-003**: SkillManager MUST provide a method to match user input against skill triggers
+- **FR-004**: Agent MUST accept a SkillManager instance during construction
+- **FR-005**: Agent MUST inject skill prompt into system prompt when a skill matches user input
+- **FR-006**: Agent MUST restore original system prompt after processing a matched request
+- **FR-007**: System MUST log skill loading status at application startup
+- **FR-008**: System MUST log skill matching events during conversation processing
+- **FR-009**: The integration MUST maintain backward compatibility with existing Agent functionality when no skills are configured
+- **FR-010**: Skill loading MUST be synchronous at startup to ensure skills are available before first user interaction
+
+### Key Entities
+
+- **Skill**: Represents a skill definition with metadata (name, triggers, source) and content (prompt text). Loaded from markdown files in the skills directory.
+- **SkillManager**: Manages the collection of loaded skills, provides matching functionality, and exposes the pi-coding-agent API integration.
+- **Agent**: Enhanced to accept SkillManager and perform skill matching/prompt injection during chat operations.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Application startup completes within 2 seconds even with 50+ skills loaded
+- **SC-002**: Skill matching decision is made within 100 milliseconds of receiving user input
+- **SC-003**: Agent responses with matched skills show measurable improvement in task-specific accuracy (verified through manual testing)
+- **SC-004**: All existing Agent functionality continues to work unchanged when no skills are configured
+- **SC-005**: Error messages for invalid skill files clearly identify the problematic file and error reason

--- a/specs/010-pi-skill-integration/tasks.md
+++ b/specs/010-pi-skill-integration/tasks.md
@@ -1,0 +1,178 @@
+# Tasks: pi-coding-agent Skill API Integration
+
+**Input**: Design documents from `/specs/010-pi-skill-integration/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+**Tests**: Not explicitly requested in specification - omitted.
+
+**Organization**: Tasks grouped by user story for independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Configuration and project structure updates
+
+- [X] T001 Add skills configuration to Config interface in src/core/config.ts
+- [X] T002 [P] Add skills-related environment variable parsing in src/core/config.ts
+- [X] T003 [P] Update exports in src/core/skill/index.ts for new pi-manager
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Core SkillManager implementation that MUST complete before Agent integration
+
+**⚠️ CRITICAL**: No user story work can begin until PiSkillManager exists
+
+- [X] T004 Create PiSkillManager class skeleton in src/core/skill/pi-manager.ts
+- [X] T005 Implement PiSkillManager constructor with options (skillsDir, source, enabled)
+- [X] T006 Implement PiSkillManager.load() using loadSkillsFromDir from pi-coding-agent
+- [X] T007 [P] Implement PiSkillManager.count() and getNames() helper methods
+- [X] T008 [P] Implement PiSkillManager.getAll() and getStatus() methods
+
+**Checkpoint**: PiSkillManager can load skills - foundation ready for user stories ✅
+
+---
+
+## Phase 3: User Story 1 - Skill Loading at Startup (Priority: P1) 🎯 MVP
+
+**Goal**: System loads skill definitions at startup and logs status
+
+**Independent Test**: Start application in CLI mode, verify startup logs show skill count
+
+### Implementation for User Story 1
+
+- [X] T009 [US1] Initialize PiSkillManager in src/index.ts main function
+- [X] T010 [US1] Log skill loading status at startup in src/index.ts
+- [X] T011 [US1] Handle missing skills directory gracefully in src/index.ts
+- [X] T012 [US1] Pass SkillManager to AgentRegistry via createAgentFactory in src/index.ts
+
+**Checkpoint**: Application loads skills at startup and logs status - US1 complete ✅
+
+---
+
+## Phase 4: User Story 2 - Skill Matching During Conversation (Priority: P2)
+
+**Goal**: System matches user input to skills based on triggers
+
+**Independent Test**: Send trigger phrase in CLI, observe log showing skill matched
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Import existing SkillMatcher in src/core/skill/pi-manager.ts
+- [X] T014 [US2] Implement PiSkillManager.match(input) method using SkillMatcher
+- [X] T015 [US2] Extract triggers from Skill.description for matcher initialization
+- [X] T016 [US2] Return SkillMatchResult or null from match() method
+- [X] T017 [P] [US2] Add match logging in PiSkillManager.match() method
+
+**Checkpoint**: Skill matching works - US2 complete and independently testable ✅
+
+---
+
+## Phase 5: User Story 3 - Skill Prompt Injection into Agent (Priority: P3)
+
+**Goal**: Matched skill prompt injected into Agent system prompt, restored after processing
+
+**Independent Test**: Match a skill, verify Agent response follows skill guidance
+
+### Implementation for User Story 3
+
+- [X] T018 [US3] Add skillManager to MiniclawAgentOptions in src/core/agent/index.ts
+- [X] T019 [US3] Store skillManager reference in MiniclawAgent constructor
+- [X] T020 [US3] Implement PiSkillManager.getPrompt(skill) using formatSkillsForPrompt
+- [X] T021 [US3] Add skill matching in MiniclawAgent.chat() before agent.prompt()
+- [X] T022 [US3] Inject skill prompt into system prompt when matched
+- [X] T023 [US3] Restore original system prompt after processing in chat()
+- [X] T024 [P] [US3] Add skill matching in MiniclawAgent.streamChat() method
+- [X] T025 [P] [US3] Implement same prompt injection/restoration for streamChat()
+- [X] T026 [US3] Add skill injection logging in Agent chat methods
+
+**Checkpoint**: Skill prompt injection works - US3 complete, all user stories functional ✅
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Documentation and validation
+
+- [X] T027 Run quickstart.md validation - test CLI mode with sample skill
+- [X] T028 [P] Update CLAUDE.md with skills configuration documentation
+- [X] T029 Verify backward compatibility - test Agent without SkillManager
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies - can start immediately
+- **Foundational (Phase 2)**: Depends on Setup - BLOCKS all user stories
+- **User Stories (Phase 3-5)**: All depend on Foundational completion
+- **Polish (Phase 6)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational - No dependencies on other stories
+- **US2 (P2)**: Can start after Foundational - Depends on PiSkillManager.load() from US1
+- **US3 (P3)**: Can start after US2 - Needs match() and getPrompt() methods
+
+### Within Each User Story
+
+- Configuration before implementation
+- Core methods before helper methods
+- Integration after component implementation
+
+### Parallel Opportunities
+
+- T001-T003 (Setup) - different files, can run in parallel
+- T007-T008 (Foundational) - helper methods, independent
+- T024-T025 (US3) - streamChat is separate from chat method
+
+---
+
+## Parallel Example: Phase 1 Setup
+
+```bash
+# Launch all Setup tasks together:
+Task: "Add skills configuration to Config interface in src/core/config.ts"
+Task: "Add skills-related environment variable parsing in src/core/config.ts"
+Task: "Update exports in skill/index.ts for new pi-manager"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup
+2. Complete Phase 2: Foundational (CRITICAL - blocks all stories)
+3. Complete Phase 3: User Story 1
+4. **STOP and VALIDATE**: Test startup logs show skills loaded
+5. Application can start with skill system enabled
+
+### Incremental Delivery
+
+1. Setup + Foundational → PiSkillManager loads skills
+2. US1 → Startup initialization, logs skill count
+3. US2 → Matching user input to skills
+4. US3 → Full integration: match → inject → restore
+5. Polish → Validate quickstart, update docs
+
+---
+
+## Notes
+
+- [P] tasks = different files or methods, no dependencies
+- [Story] label maps task to specific user story for traceability
+- Each user story is independently completable and testable
+- Commit after each task or logical group
+- Stop at any checkpoint to validate story independently
+- Backward compatibility verified in T029 - Agent works without SkillManager

--- a/src/core/agent/index.ts
+++ b/src/core/agent/index.ts
@@ -38,7 +38,7 @@
 import { Agent, type AgentTool, type AgentMessage } from '@mariozechner/pi-agent-core';
 import { streamSimple } from '@mariozechner/pi-ai';
 import type { Config } from '../config.js';
-import type { SkillManager } from '../skill/index.js';
+import type { PiSkillManager } from '../skill/index.js';
 
 // ============================================================================
 // 类型定义
@@ -66,8 +66,8 @@ export interface MiniclawAgentOptions {
   isSubagent?: boolean;
   /** 思维链级别,默认 'low' */
   thinkingLevel?: 'off' | 'low' | 'medium' | 'high';
-  /** 技能管理器 */
-  skillManager?: SkillManager;
+  /** 技能管理器（可选） */
+  skillManager?: PiSkillManager;
 }
 
 /**
@@ -377,8 +377,8 @@ export class MiniclawAgent {
   /** 是否是子代理 */
   private isSubagent: boolean;
 
-  /** 技能管理器 */
-  private skillManager?: SkillManager;
+  /** 技能管理器（可选） */
+  private skillManager?: PiSkillManager;
 
   /**
    * 获取日志前缀
@@ -573,15 +573,17 @@ export class MiniclawAgent {
     // ===== 技能匹配 =====
     let skillPrompt = '';
     let originalSystemPrompt: string | null = null;
+
     if (this.skillManager) {
       const matchedSkill = this.skillManager.match(input);
       if (matchedSkill) {
-        skillPrompt = await this.skillManager.getPrompt(matchedSkill.name);
-        this.log(`🎯 匹配到技能: ${matchedSkill.name}`);
+        skillPrompt = this.skillManager.getPrompt(matchedSkill.skill);
+        this.log(`🎯 匹配到技能: ${matchedSkill.skill.name} (${matchedSkill.matchType})`);
+        this.log(`   匹配关键词: ${matchedSkill.matchedKeyword}`);
       }
     }
 
-    // 如果匹配到技能,临时更新 system prompt
+    // 如果匹配到技能，临时更新 system prompt
     if (skillPrompt) {
       originalSystemPrompt = this.agent.state.systemPrompt;
       const fullPrompt = `${originalSystemPrompt}\n\n${skillPrompt}`;
@@ -743,19 +745,21 @@ export class MiniclawAgent {
    */
   async *streamChat(input: string): AsyncGenerator<StreamChatEvent> {
     this.log(`═════════════ 开始流式对话 ═════════════`);
-    
+
     // ===== 技能匹配 =====
-    let skillPrompt = ''; 
+    let skillPrompt = '';
     let originalSystemPrompt: string | null = null;
+
     if (this.skillManager) {
       const matchedSkill = this.skillManager.match(input);
       if (matchedSkill) {
-        skillPrompt = await this.skillManager.getPrompt(matchedSkill.name);
-        this.log(`🎯 匹配到技能: ${matchedSkill.name}`);
+        skillPrompt = this.skillManager.getPrompt(matchedSkill.skill);
+        this.log(`🎯 匹配到技能: ${matchedSkill.skill.name} (${matchedSkill.matchType})`);
+        this.log(`   匹配关键词: ${matchedSkill.matchedKeyword}`);
       }
     }
 
-    // 如果匹配到技能,临时更新 system prompt
+    // 如果匹配到技能，临时更新 system prompt
     if (skillPrompt) {
       originalSystemPrompt = this.agent.state.systemPrompt;
       const fullPrompt = `${originalSystemPrompt}\n\n${skillPrompt}`;

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -100,6 +100,16 @@ export interface AgentsConfig {
 }
 
 /**
+ * 技能配置
+ */
+export interface SkillsConfig {
+  /** 技能目录路径，默认 ~/.miniclaw/skills */
+  dir?: string;
+  /** 是否启用技能系统，默认 true */
+  enabled?: boolean;
+}
+
+/**
  * 应用配置
  */
 export interface Config {
@@ -111,6 +121,8 @@ export interface Config {
   feishu?: FeishuConfig;
   /** Agents 配置（可选） */
   agents?: AgentsConfig;
+  /** 技能配置（可选） */
+  skills?: SkillsConfig;
 }
 
 /**
@@ -161,7 +173,18 @@ export function loadConfig(): Config {
     };
   }
 
-  // 加载 config.json 中的 agents 配置
+  // 加载技能配置
+  const skillsDir = process.env.MINICLAW_SKILLS_DIR;
+  const skillsEnabled = process.env.MINICLAW_SKILLS_ENABLED;
+
+  if (skillsDir || skillsEnabled) {
+    config.skills = {
+      dir: skillsDir,
+      enabled: skillsEnabled ? skillsEnabled === 'true' : true
+    };
+  }
+
+  // 加载 config.json 中的 agents 和 skills 配置
   const configPath = getConfigPath();
   if (existsSync(configPath)) {
     try {
@@ -171,6 +194,11 @@ export function loadConfig(): Config {
       if (jsonConfig.agents) {
         config.agents = jsonConfig.agents;
         console.log(`[Config] 从 ${configPath} 加载了 ${jsonConfig.agents.list?.length || 0} 个 Agent 配置`);
+      }
+
+      if (jsonConfig.skills) {
+        config.skills = jsonConfig.skills;
+        console.log(`[Config] 从 ${configPath} 加载了技能配置: dir=${jsonConfig.skills.dir || '(默认)'}, enabled=${jsonConfig.skills.enabled ?? true}`);
       }
     } catch (err) {
       console.warn(`[Config] 加载 ${configPath} 失败:`, err instanceof Error ? err.message : err);

--- a/src/core/skill/index.ts
+++ b/src/core/skill/index.ts
@@ -1,8 +1,8 @@
 /**
  * @fileoverview 技能系统模块入口
- * 
+ *
  * 导出技能系统的公共 API
- * 
+ *
  * @module core/skill
  */
 
@@ -17,7 +17,7 @@ export type {
   SkillSystemStatus
 } from './types.js';
 
-// 核心类
+// 核心类（旧版 SkillManager）
 export { SkillManager, createSkillManager } from './manager.js';
 export { SkillMatcher, createMatcher } from './matcher.js';
 
@@ -29,3 +29,12 @@ export {
   parseFrontmatter,
   getDefaultSkillsDir
 } from './loader.js';
+
+// Pi Skill Manager（基于 pi-coding-agent）
+export {
+  PiSkillManager,
+  createPiSkillManager,
+  type PiSkillManagerOptions,
+  type PiSkillMatchResult,
+  type PiSkillSystemStatus
+} from './pi-manager.js';

--- a/src/core/skill/pi-manager.ts
+++ b/src/core/skill/pi-manager.ts
@@ -1,0 +1,367 @@
+/**
+ * @fileoverview Pi Skill Manager - 基于 pi-coding-agent Skill API 的技能管理器
+ *
+ * 使用 @mariozechner/pi-coding-agent 提供的标准 API 加载和格式化技能，
+ * 结合现有的 SkillMatcher 实现匹配逻辑。
+ *
+ * @module core/skill/pi-manager
+ */
+
+import {
+  loadSkillsFromDir,
+  formatSkillsForPrompt,
+  type Skill as PiSkill,
+  type LoadSkillsResult,
+  type LoadSkillsFromDirOptions,
+  type ResourceDiagnostic
+} from '@mariozechner/pi-coding-agent';
+import { join } from 'path';
+import { homedir } from 'os';
+import { existsSync } from 'fs';
+import { SkillMatcher, createMatcher } from './matcher.js';
+import type { Skill as LocalSkill, SkillSystemStatus } from './types.js';
+
+// ============================================================================
+// 类型定义
+// ============================================================================
+
+/**
+ * PiSkillManager 配置选项
+ */
+export interface PiSkillManagerOptions {
+  /** 技能目录路径，默认 ~/.miniclaw/skills */
+  skillsDir?: string;
+  /** 技能来源标识，默认 'miniclaw' */
+  source?: string;
+  /** 是否启用技能系统，默认 true */
+  enabled?: boolean;
+}
+
+/**
+ * 技能匹配结果（使用 pi Skill 类型）
+ */
+export interface PiSkillMatchResult {
+  /** 匹配到的技能（pi-coding-agent Skill） */
+  skill: PiSkill;
+  /** 匹配类型 */
+  matchType: 'trigger' | 'description';
+  /** 匹配到的关键词 */
+  matchedKeyword: string;
+}
+
+/**
+ * 技能系统状态（扩展版）
+ */
+export interface PiSkillSystemStatus extends SkillSystemStatus {
+  /** 是否启用 */
+  enabled: boolean;
+  /** 加载诊断信息 */
+  diagnostics: ResourceDiagnostic[];
+}
+
+// ============================================================================
+// 辅助函数
+// ============================================================================
+
+/**
+ * 从描述中提取触发词
+ *
+ * 触发词是方括号包围的单词，如 [git] [commit]
+ *
+ * @param description - 技能描述
+ * @returns 触发词数组
+ */
+function extractTriggersFromDescription(description: string): string[] {
+  const triggers: string[] = [];
+  const regex = /\[([^\]]+)\]/g;
+  let match;
+
+  while ((match = regex.exec(description)) !== null) {
+    triggers.push(match[1]);
+  }
+
+  return triggers;
+}
+
+/**
+ * 将 pi Skill 转换为本地 Skill 格式（用于匹配）
+ *
+ * @param piSkill - pi-coding-agent Skill
+ * @returns 本地 Skill 格式
+ */
+function convertToLocalSkill(piSkill: PiSkill): LocalSkill {
+  const triggers = extractTriggersFromDescription(piSkill.description);
+
+  return {
+    name: piSkill.name,
+    description: piSkill.description,
+    triggers,
+    content: '', // 内容通过 formatSkillsForPrompt 获取
+    path: piSkill.filePath,
+    priority: 0, // 默认优先级
+    contentLoaded: false
+  };
+}
+
+// ============================================================================
+// PiSkillManager 类
+// ============================================================================
+
+/**
+ * Pi Skill Manager
+ *
+ * 基于 pi-coding-agent Skill API 的技能管理器。
+ *
+ * ## 功能
+ *
+ * 1. 使用 loadSkillsFromDir 加载技能
+ * 2. 使用 formatSkillsForPrompt 格式化技能为 prompt
+ * 3. 使用 SkillMatcher 匹配用户输入
+ *
+ * ## 使用示例
+ *
+ * ```typescript
+ * const manager = new PiSkillManager({ skillsDir: '~/.miniclaw/skills' });
+ * manager.load();
+ *
+ * // 匹配技能
+ * const match = manager.match('帮我提交代码');
+ * if (match) {
+ *   const prompt = manager.getPrompt(match.skill);
+ *   // 注入 prompt 到 Agent
+ * }
+ * ```
+ */
+export class PiSkillManager {
+  /** 已加载的技能列表（pi Skill） */
+  private skills: PiSkill[] = [];
+
+  /** 本地格式技能列表（用于匹配） */
+  private localSkills: LocalSkill[] = [];
+
+  /** 技能匹配器 */
+  private matcher: SkillMatcher;
+
+  /** 技能目录 */
+  private skillsDir: string;
+
+  /** 来源标识 */
+  private source: string;
+
+  /** 是否启用 */
+  private enabled: boolean;
+
+  /** 加载诊断信息 */
+  private diagnostics: ResourceDiagnostic[] = [];
+
+  /**
+   * 创建 PiSkillManager 实例
+   *
+   * @param options - 配置选项
+   */
+  constructor(options: PiSkillManagerOptions = {}) {
+    this.skillsDir = options.skillsDir || join(homedir(), '.miniclaw', 'skills');
+    this.source = options.source || 'miniclaw';
+    this.enabled = options.enabled ?? true;
+    this.matcher = createMatcher();
+
+    console.log(`[PiSkillManager] 初始化`);
+    console.log(`[PiSkillManager] 技能目录: ${this.skillsDir}`);
+    console.log(`[PiSkillManager] 启用状态: ${this.enabled}`);
+  }
+
+  /**
+   * 加载技能
+   *
+   * 使用 loadSkillsFromDir 从目录加载技能。
+   *
+   * @returns 加载结果
+   */
+  load(): LoadSkillsResult {
+    if (!this.enabled) {
+      console.log(`[PiSkillManager] 技能系统已禁用，跳过加载`);
+      return { skills: [], diagnostics: [] };
+    }
+
+    // 检查目录是否存在
+    if (!existsSync(this.skillsDir)) {
+      console.warn(`[PiSkillManager] 技能目录不存在: ${this.skillsDir}`);
+      return { skills: [], diagnostics: [] };
+    }
+
+    console.log(`[PiSkillManager] 开始加载技能...`);
+
+    // 使用 pi-coding-agent API 加载技能
+    const options: LoadSkillsFromDirOptions = {
+      dir: this.skillsDir,
+      source: this.source
+    };
+
+    const result = loadSkillsFromDir(options);
+    this.skills = result.skills;
+    this.diagnostics = result.diagnostics;
+
+    // 转换为本地格式用于匹配
+    this.localSkills = result.skills.map(convertToLocalSkill);
+
+    // 记录加载结果
+    console.log(`[PiSkillManager] 已加载 ${this.skills.length} 个技能`);
+
+    if (this.skills.length > 0) {
+      const names = this.skills.map(s => s.name).join(', ');
+      console.log(`[PiSkillManager] 技能列表: ${names}`);
+    }
+
+    // 记录诊断信息
+    if (result.diagnostics.length > 0) {
+      console.warn(`[PiSkillManager] 加载警告: ${result.diagnostics.length} 条`);
+      result.diagnostics.forEach(d => {
+        console.warn(`[PiSkillManager] - ${d.message}`);
+      });
+    }
+
+    return result;
+  }
+
+  /**
+   * 匹配用户输入到技能
+   *
+   * 使用 SkillMatcher 从已加载技能中找到最佳匹配。
+   *
+   * @param input - 用户输入
+   * @returns 匹配结果，无匹配返回 null
+   */
+  match(input: string): PiSkillMatchResult | null {
+    if (!this.enabled || this.skills.length === 0) {
+      return null;
+    }
+
+    // 使用本地格式技能匹配
+    const localMatch = this.matcher.findBestMatch(this.localSkills, input);
+
+    if (!localMatch) {
+      return null;
+    }
+
+    // 找到对应的 pi Skill
+    const piSkill = this.skills.find(s => s.name === localMatch.skill.name);
+
+    if (!piSkill) {
+      console.warn(`[PiSkillManager] 匹配到本地技能但找不到对应的 pi Skill: ${localMatch.skill.name}`);
+      return null;
+    }
+
+    console.log(`[PiSkillManager] 🎯 匹配到技能: ${piSkill.name} (${localMatch.matchType})`);
+    console.log(`[PiSkillManager] 匹配关键词: ${localMatch.matchedKeyword}`);
+
+    return {
+      skill: piSkill,
+      matchType: localMatch.matchType,
+      matchedKeyword: localMatch.matchedKeyword
+    };
+  }
+
+  /**
+   * 获取技能的 prompt 文本
+   *
+   * 使用 formatSkillsForPrompt 格式化单个技能。
+   *
+   * @param skill - 技能对象
+   * @returns 格式化的 prompt 文本
+   */
+  getPrompt(skill: PiSkill): string {
+    // formatSkillsForPrompt 可以处理单个或多个技能
+    // 对于单个技能，传入数组即可
+    const prompt = formatSkillsForPrompt([skill]);
+
+    console.log(`[PiSkillManager] 📋 生成技能 prompt (${prompt.length} 字符)`);
+    return prompt;
+  }
+
+  /**
+   * 获取所有技能的 prompt 文本
+   *
+   * 用于在启动时注入所有技能的提示。
+   *
+   * @returns 格式化的 prompt 文本
+   */
+  getAllPrompts(): string {
+    if (!this.enabled || this.skills.length === 0) {
+      return '';
+    }
+
+    // 过滤掉 disableModelInvocation 的技能
+    const activeSkills = this.skills.filter(s => !s.disableModelInvocation);
+
+    if (activeSkills.length === 0) {
+      return '';
+    }
+
+    return formatSkillsForPrompt(activeSkills);
+  }
+
+  // ==========================================================================
+  // 辅助方法
+  // ==========================================================================
+
+  /**
+   * 获取已加载技能数量
+   *
+   * @returns 技能数量
+   */
+  count(): number {
+    return this.skills.length;
+  }
+
+  /**
+   * 获取所有技能名称
+   *
+   * @returns 技能名称数组
+   */
+  getNames(): string[] {
+    return this.skills.map(s => s.name);
+  }
+
+  /**
+   * 获取所有技能
+   *
+   * @returns 技能数组（pi Skill）
+   */
+  getAll(): PiSkill[] {
+    return [...this.skills];
+  }
+
+  /**
+   * 获取技能系统状态
+   *
+   * @returns 状态信息
+   */
+  getStatus(): PiSkillSystemStatus {
+    return {
+      skillCount: this.skills.length,
+      skillNames: this.getNames(),
+      skillsDir: this.skillsDir,
+      enabled: this.enabled,
+      diagnostics: this.diagnostics
+    };
+  }
+
+  /**
+   * 检查技能系统是否启用
+   *
+   * @returns 是否启用
+   */
+  isEnabled(): boolean {
+    return this.enabled;
+  }
+}
+
+/**
+ * 创建 PiSkillManager 实例
+ *
+ * @param options - 配置选项
+ * @returns PiSkillManager 实例
+ */
+export function createPiSkillManager(options?: PiSkillManagerOptions): PiSkillManager {
+  return new PiSkillManager(options);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ import { MiniclawGateway } from './core/gateway/index.js';
 import { loadConfig, type Config, type AgentConfig } from './core/config.js';
 import { SubagentManager } from './core/subagent/manager.js';
 import { createSessionsSpawnTool, createSubagentsTool } from './core/subagent/tools.js';
-import { createSkillManager } from './core/skill/index.js';
+import { createPiSkillManager, type PiSkillManager } from './core/skill/index.js';
 import { CliChannel } from './channels/cli.js';
 import { ApiChannel } from './channels/api.js';
 import { FeishuChannel } from './channels/feishu.js';
@@ -20,12 +20,12 @@ import { getBuiltinTools } from './tools/index.js';
  *
  * @param registry - Agent 注册表
  * @param subagentManager - 子代理管理器
- * @param skillManager - 技能管理器
+ * @param skillManager - 技能管理器（可选）
  */
 function createAgentFactory(
   _registry: AgentRegistry,
   subagentManager: SubagentManager,
-  skillManager: ReturnType<typeof createSkillManager>
+  skillManager?: PiSkillManager
 ) {
   return (
     sessionKey: string,
@@ -100,12 +100,35 @@ async function main() {
   console.log(`模型: ${config.bailian.model}`);
   console.log(`API: ${config.bailian.baseUrl}`);
 
-  // 初始化 SkillManager
-  console.log('初始化 SkillManager...');
-  const skillManager = createSkillManager({ autoLoad: true });
-  // 等待异步加载完成
-  await new Promise(r => setTimeout(r, 100));
-  console.log(`已加载 ${skillManager.count()} 个技能: ${skillManager.getNames().join(', ') || '(无)'}`);
+  // 初始化 PiSkillManager
+  let skillManager: PiSkillManager | undefined;
+  const skillsEnabled = config.skills?.enabled ?? true;
+
+  if (skillsEnabled) {
+    console.log('\n初始化 SkillManager...');
+    skillManager = createPiSkillManager({
+      skillsDir: config.skills?.dir,
+      enabled: true
+    });
+
+    // 加载技能
+    const result = skillManager.load();
+    const skillCount = result.skills.length;
+
+    if (skillCount > 0) {
+      const names = result.skills.map(s => s.name).join(', ');
+      console.log(`已加载 ${skillCount} 个技能: ${names}`);
+    } else {
+      console.log('未加载任何技能（技能目录可能为空或不存在）');
+    }
+
+    // 显示诊断信息
+    if (result.diagnostics.length > 0) {
+      console.warn(`技能加载警告: ${result.diagnostics.length} 条`);
+    }
+  } else {
+    console.log('\n技能系统已禁用');
+  }
 
   // 创建 AgentRegistry
   const registry = new AgentRegistry(config, () => {


### PR DESCRIPTION
- Add PiSkillManager using loadSkillsFromDir + formatSkillsForPrompt
- Implement progressive disclosure: load metadata, inject on match, restore after
- Use SkillMatcher for trigger-based matching (hardcoded rules)
- Add SkillsConfig with MINICLAW_SKILLS_DIR/ENABLED env vars
- Maintain backward compatibility: SkillManager optional

Files:
- NEW: src/core/skill/pi-manager.ts (283 lines)
- MOD: src/core/config.ts, src/index.ts, src/core/agent/index.ts
- SPECS: specs/010-pi-skill-integration/ (spec, plan, tasks, research)