### PR TITLE
refactor(skill): 废弃旧版 SkillManager，统一使用 PiSkillManager

### DIFF
--- a/src/core/skill/index.ts
+++ b/src/core/skill/index.ts
@@ -17,20 +17,10 @@ export type {
   SkillSystemStatus
 } from './types.js';
 
-// 核心类（旧版 SkillManager）
-export { SkillManager, createSkillManager } from './manager.js';
+// 匹配器（仍被 PiSkillManager 使用）
 export { SkillMatcher, createMatcher } from './matcher.js';
 
-// 工具函数
-export {
-  loadSkill,
-  loadAllSkills,
-  extractTriggers,
-  parseFrontmatter,
-  getDefaultSkillsDir
-} from './loader.js';
-
-// Pi Skill Manager（基于 pi-coding-agent）
+// Pi Skill Manager（基于 pi-coding-agent，推荐使用）
 export {
   PiSkillManager,
   createPiSkillManager,
@@ -38,3 +28,19 @@ export {
   type PiSkillMatchResult,
   type PiSkillSystemStatus
 } from './pi-manager.js';
+
+// ============================================================================
+// 以下为旧版实现，已废弃，保留供参考
+// ============================================================================
+
+// 旧版 SkillManager（已废弃，请使用 PiSkillManager）
+// export { SkillManager, createSkillManager } from './manager.js';
+
+// 旧版加载器（已废弃，pi-coding-agent 内置加载能力）
+// export {
+//   loadSkill,
+//   loadAllSkills,
+//   extractTriggers,
+//   parseFrontmatter,
+//   getDefaultSkillsDir
+// } from './loader.js';

--- a/src/core/skill/loader.ts
+++ b/src/core/skill/loader.ts
@@ -1,8 +1,13 @@
 /**
  * @fileoverview 技能加载器
  * 
- * 负责从 SKILL.md 文件加载技能，解析 YAML frontmatter
+ * @deprecated 已废弃，pi-coding-agent 内置加载能力
  * 
+ * 此文件保留供参考，新项目应使用 PiSkillManager 和 pi-coding-agent 的 API。
+ * pi-coding-agent 提供了更标准的 loadSkillsFromDir() 和 formatSkillsForPrompt() 方法。
+ * 
+ * 负责从 SKILL.md 文件加载技能，解析 YAML frontmatter
+ *
  * @module core/skill/loader
  */
 

--- a/src/core/skill/manager.ts
+++ b/src/core/skill/manager.ts
@@ -1,6 +1,11 @@
 /**
  * @fileoverview 技能管理器
  *
+ * @deprecated 已废弃，请使用 PiSkillManager（基于 pi-coding-agent）
+ * 
+ * 此文件保留供参考，新项目应使用 pi-manager.ts 中的 PiSkillManager。
+ * PiSkillManager 提供更好的兼容性和更简洁的 API。
+ *
  * 管理技能的加载、注册、匹配和检索
  *
  * @module core/skill/manager

--- a/src/core/skill/types.ts
+++ b/src/core/skill/types.ts
@@ -3,6 +3,8 @@
  * 
  * 定义技能、技能管理器配置、匹配结果等核心类型
  * 
+ * 注意：部分类型被 PiSkillManager 使用，部分仅为旧版 SkillManager 定义
+ *
  * @module core/skill/types
  */
 


### PR DESCRIPTION
- 注释掉旧版 SkillManager 和 loader 的导出
- 添加 @deprecated 标记到 manager.ts 和 loader.ts
- 保留旧代码供参考，新项目应使用 PiSkillManager
- 更新 index.ts 只导出推荐的 API