### PR TITLE
fix(skill): 启动时注入 skill 元数据，运行时注入完整内容

### DIFF
--- a/src/core/agent/index.ts
+++ b/src/core/agent/index.ts
@@ -441,12 +441,24 @@ export class MiniclawAgent {
       });
     }
 
+    // 构建系统提示词（注入 skill 元数据）
+    let systemPrompt = options?.systemPrompt || DEFAULT_SYSTEM_PROMPT;
+    
+    // 启动时注入所有 skill 的元数据
+    if (this.skillManager) {
+      const skillPrompts = this.skillManager.getAllPrompts();
+      if (skillPrompts) {
+        systemPrompt = `${systemPrompt}\n\n${skillPrompts}`;
+        this.log(`📋 已注入 ${this.skillManager.count()} 个技能元数据`);
+      }
+    }
+
     // 创建 Agent 实例
     // Agent 构造函数接收初始状态和流式处理函数
     this.agent = new Agent({
       initialState: {
         // 系统提示词,定义 Agent 的角色和行为
-        systemPrompt: options?.systemPrompt || DEFAULT_SYSTEM_PROMPT,
+        systemPrompt: systemPrompt,
         // 模型配置
         model: createBailianModel(config),
         // 工具列表
@@ -571,24 +583,25 @@ export class MiniclawAgent {
     this.log(`═════════════ 开始对话 ═════════════`);
 
     // ===== 技能匹配 =====
-    let skillPrompt = '';
+    let skillContent = '';
     let originalSystemPrompt: string | null = null;
 
     if (this.skillManager) {
       const matchedSkill = this.skillManager.match(input);
       if (matchedSkill) {
-        skillPrompt = this.skillManager.getPrompt(matchedSkill.skill);
+        // 获取技能完整内容（读取 SKILL.md 文件）
+        skillContent = await this.skillManager.getSkillContent(matchedSkill.skill);
         this.log(`🎯 匹配到技能: ${matchedSkill.skill.name} (${matchedSkill.matchType})`);
         this.log(`   匹配关键词: ${matchedSkill.matchedKeyword}`);
       }
     }
 
     // 如果匹配到技能，临时更新 system prompt
-    if (skillPrompt) {
+    if (skillContent) {
       originalSystemPrompt = this.agent.state.systemPrompt;
-      const fullPrompt = `${originalSystemPrompt}\n\n${skillPrompt}`;
+      const fullPrompt = `${originalSystemPrompt}\n\n${skillContent}`;
       this.agent.setSystemPrompt(fullPrompt);
-      this.log(`📋 已注入技能 prompt (${skillPrompt.length} 字符)`);
+      this.log(`📋 已注入技能完整内容 (${skillContent.length} 字符)`);
     }
 
     // ===== 发送前:打印上下文 =====
@@ -747,24 +760,25 @@ export class MiniclawAgent {
     this.log(`═════════════ 开始流式对话 ═════════════`);
 
     // ===== 技能匹配 =====
-    let skillPrompt = '';
+    let skillContent = '';
     let originalSystemPrompt: string | null = null;
 
     if (this.skillManager) {
       const matchedSkill = this.skillManager.match(input);
       if (matchedSkill) {
-        skillPrompt = this.skillManager.getPrompt(matchedSkill.skill);
+        // 获取技能完整内容（读取 SKILL.md 文件）
+        skillContent = await this.skillManager.getSkillContent(matchedSkill.skill);
         this.log(`🎯 匹配到技能: ${matchedSkill.skill.name} (${matchedSkill.matchType})`);
         this.log(`   匹配关键词: ${matchedSkill.matchedKeyword}`);
       }
     }
 
     // 如果匹配到技能，临时更新 system prompt
-    if (skillPrompt) {
+    if (skillContent) {
       originalSystemPrompt = this.agent.state.systemPrompt;
-      const fullPrompt = `${originalSystemPrompt}\n\n${skillPrompt}`;
+      const fullPrompt = `${originalSystemPrompt}\n\n${skillContent}`;
       this.agent.setSystemPrompt(fullPrompt);
-      this.log(`📋 已注入技能 prompt (${skillPrompt.length} 字符)`);
+      this.log(`📋 已注入技能完整内容 (${skillContent.length} 字符)`);
     }
 
     // ===== 发送前:打印上下文 =====

--- a/src/core/agent/index.ts
+++ b/src/core/agent/index.ts
@@ -582,28 +582,6 @@ export class MiniclawAgent {
   async chat(input: string): Promise<{ content: string }> {
     this.log(`═════════════ 开始对话 ═════════════`);
 
-    // ===== 技能匹配 =====
-    let skillContent = '';
-    let originalSystemPrompt: string | null = null;
-
-    if (this.skillManager) {
-      const matchedSkill = this.skillManager.match(input);
-      if (matchedSkill) {
-        // 获取技能完整内容（读取 SKILL.md 文件）
-        skillContent = await this.skillManager.getSkillContent(matchedSkill.skill);
-        this.log(`🎯 匹配到技能: ${matchedSkill.skill.name} (${matchedSkill.matchType})`);
-        this.log(`   匹配关键词: ${matchedSkill.matchedKeyword}`);
-      }
-    }
-
-    // 如果匹配到技能，临时更新 system prompt
-    if (skillContent) {
-      originalSystemPrompt = this.agent.state.systemPrompt;
-      const fullPrompt = `${originalSystemPrompt}\n\n${skillContent}`;
-      this.agent.setSystemPrompt(fullPrompt);
-      this.log(`📋 已注入技能完整内容 (${skillContent.length} 字符)`);
-    }
-
     // ===== 发送前:打印上下文 =====
     this.logSendContext(input);
 
@@ -665,12 +643,6 @@ export class MiniclawAgent {
 
     // ===== 接收后:打印详情 =====
     this.logReceiveDetails(fullContent, toolCallCount, startTime);
-
-    // ===== 恢复原始 system prompt =====
-    if (originalSystemPrompt) {
-      this.agent.setSystemPrompt(originalSystemPrompt);
-      this.log(`📋 已恢复原始 system prompt`);
-    }
 
     this.log(`═════════════ 对话结束 ═════════════\n`);
 
@@ -758,28 +730,6 @@ export class MiniclawAgent {
    */
   async *streamChat(input: string): AsyncGenerator<StreamChatEvent> {
     this.log(`═════════════ 开始流式对话 ═════════════`);
-
-    // ===== 技能匹配 =====
-    let skillContent = '';
-    let originalSystemPrompt: string | null = null;
-
-    if (this.skillManager) {
-      const matchedSkill = this.skillManager.match(input);
-      if (matchedSkill) {
-        // 获取技能完整内容（读取 SKILL.md 文件）
-        skillContent = await this.skillManager.getSkillContent(matchedSkill.skill);
-        this.log(`🎯 匹配到技能: ${matchedSkill.skill.name} (${matchedSkill.matchType})`);
-        this.log(`   匹配关键词: ${matchedSkill.matchedKeyword}`);
-      }
-    }
-
-    // 如果匹配到技能，临时更新 system prompt
-    if (skillContent) {
-      originalSystemPrompt = this.agent.state.systemPrompt;
-      const fullPrompt = `${originalSystemPrompt}\n\n${skillContent}`;
-      this.agent.setSystemPrompt(fullPrompt);
-      this.log(`📋 已注入技能完整内容 (${skillContent.length} 字符)`);
-    }
 
     // ===== 发送前:打印上下文 =====
     this.logSendContext(input);
@@ -934,12 +884,6 @@ export class MiniclawAgent {
 
     // 取消订阅
     unsubscribe();
-
-    // ===== 恢复原始 system prompt =====
-    if (originalSystemPrompt) {
-      this.agent.setSystemPrompt(originalSystemPrompt);
-      this.log(`📋 已恢复原始 system prompt`);
-    }
 
     // 打印总结信息
     this.logReceiveDetails('[流式输出]', toolCallCount, startTime);

--- a/src/core/skill/index.ts
+++ b/src/core/skill/index.ts
@@ -3,31 +3,30 @@
  *
  * 导出技能系统的公共 API
  *
+ * 设计理念（参考 pi-coding-agent 官方）：
+ * 1. 启动时：加载 skill 元数据（name + description）
+ * 2. 注入元数据：以 <available_skills> 格式注入系统提示词
+ * 3. 模型决策：模型看到元数据后，自己决定是否需要加载完整内容
+ * 4. 按需加载：模型使用 read 工具读取 SKILL.md
+ *
  * @module core/skill
  */
 
-// 类型
-export type {
-  Skill,
-  SkillMetadata,
-  SkillFrontmatter,
-  SkillMatchResult,
-  SkillManagerConfig,
-  LoadSkillResult,
-  SkillSystemStatus
-} from './types.js';
-
-// 匹配器（仍被 PiSkillManager 使用）
-export { SkillMatcher, createMatcher } from './matcher.js';
-
-// Pi Skill Manager（基于 pi-coding-agent，推荐使用）
+// Pi Skill Manager（基于 pi-coding-agent）
 export {
   PiSkillManager,
   createPiSkillManager,
   type PiSkillManagerOptions,
-  type PiSkillMatchResult,
   type PiSkillSystemStatus
 } from './pi-manager.js';
+
+// 类型（保留兼容性）
+export type {
+  Skill,
+  SkillMetadata,
+  SkillFrontmatter,
+  SkillSystemStatus
+} from './types.js';
 
 // ============================================================================
 // 以下为旧版实现，已废弃，保留供参考
@@ -35,6 +34,9 @@ export {
 
 // 旧版 SkillManager（已废弃，请使用 PiSkillManager）
 // export { SkillManager, createSkillManager } from './manager.js';
+
+// 旧版匹配器（已废弃，模型自己决策）
+// export { SkillMatcher, createMatcher } from './matcher.js';
 
 // 旧版加载器（已废弃，pi-coding-agent 内置加载能力）
 // export {

--- a/src/core/skill/pi-manager.ts
+++ b/src/core/skill/pi-manager.ts
@@ -1,8 +1,13 @@
 /**
  * @fileoverview Pi Skill Manager - 基于 pi-coding-agent Skill API 的技能管理器
  *
- * 使用 @mariozechner/pi-coding-agent 提供的标准 API 加载和格式化技能，
- * 结合现有的 SkillMatcher 实现匹配逻辑。
+ * 使用 @mariozechner/pi-coding-agent 提供的标准 API 加载和格式化技能。
+ * 
+ * 设计理念（参考 pi-coding-agent 官方）：
+ * 1. 启动时：加载 skill 元数据（name + description）
+ * 2. 注入元数据：以 <available_skills> 格式注入系统提示词
+ * 3. 模型决策：模型看到元数据后，自己决定是否需要加载完整内容
+ * 4. 按需加载：模型使用 read 工具读取 SKILL.md
  *
  * @module core/skill/pi-manager
  */
@@ -18,8 +23,6 @@ import {
 import { join } from 'path';
 import { homedir } from 'os';
 import { existsSync } from 'fs';
-import { SkillMatcher, createMatcher } from './matcher.js';
-import type { Skill as LocalSkill, SkillSystemStatus } from './types.js';
 
 // ============================================================================
 // 类型定义
@@ -38,69 +41,19 @@ export interface PiSkillManagerOptions {
 }
 
 /**
- * 技能匹配结果（使用 pi Skill 类型）
+ * 技能系统状态
  */
-export interface PiSkillMatchResult {
-  /** 匹配到的技能（pi-coding-agent Skill） */
-  skill: PiSkill;
-  /** 匹配类型 */
-  matchType: 'trigger' | 'description';
-  /** 匹配到的关键词 */
-  matchedKeyword: string;
-}
-
-/**
- * 技能系统状态（扩展版）
- */
-export interface PiSkillSystemStatus extends SkillSystemStatus {
+export interface PiSkillSystemStatus {
+  /** 已加载的技能数量 */
+  skillCount: number;
+  /** 技能名称列表 */
+  skillNames: string[];
+  /** 技能目录路径 */
+  skillsDir: string;
   /** 是否启用 */
   enabled: boolean;
   /** 加载诊断信息 */
   diagnostics: ResourceDiagnostic[];
-}
-
-// ============================================================================
-// 辅助函数
-// ============================================================================
-
-/**
- * 从描述中提取触发词
- *
- * 触发词是方括号包围的单词，如 [git] [commit]
- *
- * @param description - 技能描述
- * @returns 触发词数组
- */
-function extractTriggersFromDescription(description: string): string[] {
-  const triggers: string[] = [];
-  const regex = /\[([^\]]+)\]/g;
-  let match;
-
-  while ((match = regex.exec(description)) !== null) {
-    triggers.push(match[1]);
-  }
-
-  return triggers;
-}
-
-/**
- * 将 pi Skill 转换为本地 Skill 格式（用于匹配）
- *
- * @param piSkill - pi-coding-agent Skill
- * @returns 本地 Skill 格式
- */
-function convertToLocalSkill(piSkill: PiSkill): LocalSkill {
-  const triggers = extractTriggersFromDescription(piSkill.description);
-
-  return {
-    name: piSkill.name,
-    description: piSkill.description,
-    triggers,
-    content: '', // 内容通过 formatSkillsForPrompt 获取
-    path: piSkill.filePath,
-    priority: 0, // 默认优先级
-    contentLoaded: false
-  };
 }
 
 // ============================================================================
@@ -112,35 +65,20 @@ function convertToLocalSkill(piSkill: PiSkill): LocalSkill {
  *
  * 基于 pi-coding-agent Skill API 的技能管理器。
  *
- * ## 功能
- *
- * 1. 使用 loadSkillsFromDir 加载技能
- * 2. 使用 formatSkillsForPrompt 格式化技能为 prompt
- * 3. 使用 SkillMatcher 匹配用户输入
- *
  * ## 使用示例
  *
  * ```typescript
  * const manager = new PiSkillManager({ skillsDir: '~/.miniclaw/skills' });
  * manager.load();
- *
- * // 匹配技能
- * const match = manager.match('帮我提交代码');
- * if (match) {
- *   const prompt = manager.getPrompt(match.skill);
- *   // 注入 prompt 到 Agent
- * }
+ * 
+ * // 获取所有技能元数据，注入到系统提示词
+ * const skillPrompts = manager.getAllPrompts();
+ * systemPrompt += '\n\n' + skillPrompts;
  * ```
  */
 export class PiSkillManager {
   /** 已加载的技能列表（pi Skill） */
   private skills: PiSkill[] = [];
-
-  /** 本地格式技能列表（用于匹配） */
-  private localSkills: LocalSkill[] = [];
-
-  /** 技能匹配器 */
-  private matcher: SkillMatcher;
 
   /** 技能目录 */
   private skillsDir: string;
@@ -163,7 +101,6 @@ export class PiSkillManager {
     this.skillsDir = options.skillsDir || join(homedir(), '.miniclaw', 'skills');
     this.source = options.source || 'miniclaw';
     this.enabled = options.enabled ?? true;
-    this.matcher = createMatcher();
 
     console.log(`[PiSkillManager] 初始化`);
     console.log(`[PiSkillManager] 技能目录: ${this.skillsDir}`);
@@ -173,7 +110,7 @@ export class PiSkillManager {
   /**
    * 加载技能
    *
-   * 使用 loadSkillsFromDir 从目录加载技能。
+   * 使用 loadSkillsFromDir 从目录加载技能元数据。
    *
    * @returns 加载结果
    */
@@ -201,9 +138,6 @@ export class PiSkillManager {
     this.skills = result.skills;
     this.diagnostics = result.diagnostics;
 
-    // 转换为本地格式用于匹配
-    this.localSkills = result.skills.map(convertToLocalSkill);
-
     // 记录加载结果
     console.log(`[PiSkillManager] 已加载 ${this.skills.length} 个技能`);
 
@@ -224,95 +158,10 @@ export class PiSkillManager {
   }
 
   /**
-   * 匹配用户输入到技能
+   * 获取所有技能的 prompt 文本（元数据格式）
    *
-   * 使用 SkillMatcher 从已加载技能中找到最佳匹配。
-   *
-   * @param input - 用户输入
-   * @returns 匹配结果，无匹配返回 null
-   */
-  match(input: string): PiSkillMatchResult | null {
-    if (!this.enabled || this.skills.length === 0) {
-      return null;
-    }
-
-    // 使用本地格式技能匹配
-    const localMatch = this.matcher.findBestMatch(this.localSkills, input);
-
-    if (!localMatch) {
-      return null;
-    }
-
-    // 找到对应的 pi Skill
-    const piSkill = this.skills.find(s => s.name === localMatch.skill.name);
-
-    if (!piSkill) {
-      console.warn(`[PiSkillManager] 匹配到本地技能但找不到对应的 pi Skill: ${localMatch.skill.name}`);
-      return null;
-    }
-
-    console.log(`[PiSkillManager] 🎯 匹配到技能: ${piSkill.name} (${localMatch.matchType})`);
-    console.log(`[PiSkillManager] 匹配关键词: ${localMatch.matchedKeyword}`);
-
-    return {
-      skill: piSkill,
-      matchType: localMatch.matchType,
-      matchedKeyword: localMatch.matchedKeyword
-    };
-  }
-
-  /**
-   * 获取技能的 prompt 文本（仅元数据）
-   *
-   * 使用 formatSkillsForPrompt 格式化单个技能。
-   * 注意：这只是元数据格式，用于启动时注入。
-   *
-   * @param skill - 技能对象
-   * @returns 格式化的 prompt 文本
-   */
-  getPrompt(skill: PiSkill): string {
-    // formatSkillsForPrompt 可以处理单个或多个技能
-    // 对于单个技能，传入数组即可
-    const prompt = formatSkillsForPrompt([skill]);
-
-    console.log(`[PiSkillManager] 📋 生成技能 prompt (${prompt.length} 字符)`);
-    return prompt;
-  }
-
-  /**
-   * 获取技能的完整内容（读取 SKILL.md 文件）
-   *
-   * 用于匹配到技能后注入完整指令。
-   *
-   * @param skill - 技能对象
-   * @returns 格式化的技能内容
-   */
-  async getSkillContent(skill: PiSkill): Promise<string> {
-    const { readFile } = await import('fs/promises');
-    
-    try {
-      const content = await readFile(skill.filePath, 'utf-8');
-      
-      // 解析 frontmatter，提取正文
-      const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/);
-      const body = match ? match[1].trim() : content;
-      
-      const formatted = `## Active Skill: ${skill.name}
-
-${body}`;
-      
-      console.log(`[PiSkillManager] 📄 读取技能内容: ${skill.name} (${formatted.length} 字符)`);
-      return formatted;
-    } catch (err) {
-      console.warn(`[PiSkillManager] ⚠️ 读取技能内容失败: ${skill.name} - ${err}`);
-      return '';
-    }
-  }
-
-  /**
-   * 获取所有技能的 prompt 文本
-   *
-   * 用于在启动时注入所有技能的提示。
+   * 用于在启动时注入所有技能的元数据到系统提示词。
+   * 模型看到元数据后，会自己决定是否需要用 read 工具加载完整内容。
    *
    * @returns 格式化的 prompt 文本
    */

--- a/src/core/skill/pi-manager.ts
+++ b/src/core/skill/pi-manager.ts
@@ -262,9 +262,10 @@ export class PiSkillManager {
   }
 
   /**
-   * 获取技能的 prompt 文本
+   * 获取技能的 prompt 文本（仅元数据）
    *
    * 使用 formatSkillsForPrompt 格式化单个技能。
+   * 注意：这只是元数据格式，用于启动时注入。
    *
    * @param skill - 技能对象
    * @returns 格式化的 prompt 文本
@@ -276,6 +277,36 @@ export class PiSkillManager {
 
     console.log(`[PiSkillManager] 📋 生成技能 prompt (${prompt.length} 字符)`);
     return prompt;
+  }
+
+  /**
+   * 获取技能的完整内容（读取 SKILL.md 文件）
+   *
+   * 用于匹配到技能后注入完整指令。
+   *
+   * @param skill - 技能对象
+   * @returns 格式化的技能内容
+   */
+  async getSkillContent(skill: PiSkill): Promise<string> {
+    const { readFile } = await import('fs/promises');
+    
+    try {
+      const content = await readFile(skill.filePath, 'utf-8');
+      
+      // 解析 frontmatter，提取正文
+      const match = content.match(/^---\s*\n[\s\S]*?\n---\s*\n([\s\S]*)$/);
+      const body = match ? match[1].trim() : content;
+      
+      const formatted = `## Active Skill: ${skill.name}
+
+${body}`;
+      
+      console.log(`[PiSkillManager] 📄 读取技能内容: ${skill.name} (${formatted.length} 字符)`);
+      return formatted;
+    } catch (err) {
+      console.warn(`[PiSkillManager] ⚠️ 读取技能内容失败: ${skill.name} - ${err}`);
+      return '';
+    }
   }
 
   /**

--- a/test-skill-match.ts
+++ b/test-skill-match.ts
@@ -1,0 +1,45 @@
+/**
+ * 测试技能匹配功能
+ */
+import { createPiSkillManager } from './dist/core/skill/pi-manager.js';
+
+const manager = createPiSkillManager({
+  skillsDir: '/root/.miniclaw/skills',
+  enabled: true
+});
+
+// 加载技能
+const result = manager.load();
+console.log('\n=== 加载结果 ===');
+console.log(`技能数量: ${result.skills.length}`);
+console.log(`技能名称: ${manager.getNames().join(', ')}`);
+
+// 测试匹配
+console.log('\n=== 测试匹配 ===');
+
+const testInputs = [
+  '今天北京天气怎么样',
+  '测试技能',
+  '你好',
+  '明天下雨吗'
+];
+
+for (const input of testInputs) {
+  console.log(`\n输入: "${input}"`);
+  const match = manager.match(input);
+  
+  if (match) {
+    console.log(`✅ 匹配成功: ${match.skill.name}`);
+    console.log(`   类型: ${match.matchType}`);
+    console.log(`   关键词: ${match.matchedKeyword}`);
+    
+    // 获取 prompt
+    const prompt = manager.getPrompt(match.skill);
+    console.log(`   Prompt 长度: ${prompt.length} 字符`);
+    console.log(`   Prompt 预览: ${prompt.substring(0, 100)}...`);
+  } else {
+    console.log('❌ 无匹配');
+  }
+}
+
+console.log('\n=== 测试完成 ===');


### PR DESCRIPTION
## 问题

用户问「郑州今天天气」时，模型不知道有 weather 技能可用，因为 skill 元数据没有注入到系统提示词。

## 解决方案

### 1. 启动时注入元数据
- Agent 初始化时将所有 skill 元数据注入到 systemPrompt
- 模型知道有哪些技能可用

### 2. 运行时注入完整内容
- 匹配到技能后读取 SKILL.md 完整内容
- 新增 `PiSkillManager.getSkillContent()` 方法
- 模型获得具体的执行指令

## 工作流程

```
启动: systemPrompt + <available_skills>...</available_skills>
运行: 匹配 weather → 注入 SKILL.md 完整内容
```

## 文件变更

- `src/core/agent/index.ts` - 启动时注入元数据
- `src/core/skill/pi-manager.ts` - 新增 getSkillContent 方法