### PR TITLE
feat(agent): 增加系统提示词预览长度到 3000 字符

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,8 @@ EOF
 - TypeScript 5.x / Node.js 18+ + Vitest (测试框架), pi-agent-core (Agent框架) (002-improve-test-coverage)
 - SimpleMemoryStorage (内存存储，可选文件持久化) (002-improve-test-coverage)
 - @mariozechner/pi-coding-agent (^0.65.2) for skill loading/formatting (010-pi-skill-integration)
+- TypeScript 5.9.3, Node.js >=18 + @mariozechner/pi-coding-agent v0.65.2 (provides `loadSkillsFromDir`, `formatSkillsForPrompt`), express v5.2.1, socket.io v4.8.3 (011-skill-lazy-loading)
+- File system - skills stored in ~/.miniclaw/skills/ directory as SKILL.md files (011-skill-lazy-loading)
 
 ## Recent Changes
 - 010-pi-skill-integration: Integrated pi-coding-agent Skill API for skill loading, matching, and prompt injection

--- a/src/core/agent/index.ts
+++ b/src/core/agent/index.ts
@@ -1031,8 +1031,8 @@ export class MiniclawAgent {
     // 打印系统提示词
     const systemPrompt = this.agent.state.systemPrompt;
     this.log(`📋 系统提示词 (${systemPrompt.length} 字符, ~${estimateTokens(systemPrompt)} tokens):`);
-    const promptPreview = systemPrompt.length > 500
-      ? systemPrompt.substring(0, 500) + '...'
+    const promptPreview = systemPrompt.length > 3000
+      ? systemPrompt.substring(0, 3000) + '...'
       : systemPrompt;
     this.log(`  ${promptPreview.replace(/\n/g, '\n   ')}`);
 

--- a/src/core/skill/manager.ts
+++ b/src/core/skill/manager.ts
@@ -250,10 +250,14 @@ ${skill.content}`;
    * 获取系统状态
    */
   getStatus(): SkillSystemStatus {
+    const skills = Array.from(this.skills.values());
+    const contentLoadedCount = skills.filter(s => s.contentLoaded).length;
+    
     return {
       skillCount: this.skills.size,
       skillNames: Array.from(this.skills.keys()),
-      skillsDir: this.skillsDir
+      skillsDir: this.skillsDir,
+      contentLoadedCount
     };
   }
 


### PR DESCRIPTION
## 变更说明

- 将系统提示词日志预览长度从 500 改为 3000 字符
- 确保 Skill 元数据在日志中可见
- 完整提示词约 2700 字符（2000 base + 700 skill）

## 验证

- ✅ 编译成功
- ✅ 455 测试全部通过

## 背景

之前预览长度 500 字符，Skill 元数据（约 741 字符，位于末尾）被截断，无法在日志中看到。