### PR TITLE
fix: TTL 配置传递 + 编译修复

### DIFF
--- a/src/core/subagent/verifier.ts
+++ b/src/core/subagent/verifier.ts
@@ -7,7 +7,7 @@
  */
 
 import { access, readFile } from 'fs/promises';
-import { VerificationCheck, VerificationResult, VerificationType } from './types.js';
+import { VerificationCheck, VerificationResult } from './types.js';
 
 /**
  * 验证文件是否存在


### PR DESCRIPTION
## 修复内容

### 1. TTL 配置传递 bug

**问题**: MemoryManager.defaultTTL 没传递给 ShortTermMemory，导致 TTL 固定 24h，晋升机制不触发。

**修复**:
- ShortTermMemory 构造函数增加 config 参数
- MemoryManager 传递 defaultTTL 到 ShortTermMemory

**验证**: TTL 设置 2000ms 在 3秒后正确过期并晋升。

### 2. TypeScript 编译错误

**问题**: verifier.ts 导入了未使用的 VerificationType 类型。

**修复**: 移除未使用的导入。

## 测试结果

```
Test Files: 58 passed
Tests: 760 passed
```

## 提交记录

- 68a8bca fix: 移除未使用的 VerificationType 导入
- 8c59ef9 fix(memory): TTL 配置传递到 ShortTermMemory