### PR TITLE
feat(feishu): 添加消息表情回应功能

### DIFF
--- a/src/channels/feishu-client.ts
+++ b/src/channels/feishu-client.ts
@@ -12,7 +12,8 @@ export interface FeishuConfig {
 
 export interface SendMessageParams {
   receiveId: string;
-  msgType: 'text';
+  receiveIdType?: 'open_id' | 'user_id' | 'union_id' | 'chat_id';
+  msgType: 'text' | 'post';
   content: string;
   replyToMessageId?: string;
 }
@@ -92,10 +93,22 @@ export class FeishuClient {
   async sendMessage(params: SendMessageParams): Promise<SendMessageResult> {
     const token = await this.getAccessToken();
 
+    // 构建消息内容
+    let content: string;
+    if (params.msgType === 'post') {
+      // 富文本消息（与 OpenClaw 格式一致）
+      content = JSON.stringify({
+        zh_cn: { content: [[{ tag: 'md', text: params.content }]] }
+      });
+    } else {
+      // 普通文本消息
+      content = JSON.stringify({ text: params.content });
+    }
+
     const body: Record<string, unknown> = {
       receive_id: params.receiveId,
       msg_type: params.msgType,
-      content: JSON.stringify({ text: params.content }),
+      content,
     };
 
     // 话题回复
@@ -103,8 +116,9 @@ export class FeishuClient {
       body.reply_to_message_id = params.replyToMessageId;
     }
 
+    const receiveIdType = params.receiveIdType || 'open_id';
     const response = await fetch(
-      'https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=user_id',
+      `https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=${receiveIdType}`,
       {
         method: 'POST',
         headers: {

--- a/src/channels/feishu-reactions.ts
+++ b/src/channels/feishu-reactions.ts
@@ -1,0 +1,161 @@
+/**
+ * 飞书消息表情回应
+ * 在收到消息后添加表情回应，表示正在处理
+ */
+
+export interface FeishuConfig {
+  appId: string;
+  appSecret: string;
+}
+
+export interface AddReactionResult {
+  reactionId: string;
+}
+
+interface TokenCache {
+  token: string;
+  expireAt: number;
+}
+
+interface FeishuApiResponse {
+  code: number;
+  msg?: string;
+  tenant_access_token?: string;
+  expire?: number;
+  data?: {
+    reaction_id?: string;
+  };
+}
+
+/**
+ * 飞书表情回应管理器
+ */
+export class FeishuReactions {
+  private config: FeishuConfig;
+  private tokenCache: TokenCache | null = null;
+
+  constructor(config: FeishuConfig) {
+    this.config = config;
+  }
+
+  /**
+   * 获取 tenant_access_token
+   */
+  async getAccessToken(): Promise<string> {
+    // 检查缓存
+    if (this.tokenCache && this.tokenCache.expireAt > Date.now()) {
+      return this.tokenCache.token;
+    }
+
+    const response = await fetch(
+      'https://open.feishu.cn/open-apis/auth/v3/tenant_access_token/internal',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          app_id: this.config.appId,
+          app_secret: this.config.appSecret,
+        }),
+      }
+    );
+
+    const data: FeishuApiResponse = await response.json();
+
+    if (data.code !== 0 || !data.tenant_access_token) {
+      throw new Error(`获取 token 失败: ${data.msg || `code ${data.code}`}`);
+    }
+
+    // 缓存 token（提前 5 分钟过期）
+    this.tokenCache = {
+      token: data.tenant_access_token,
+      expireAt: Date.now() + (data.expire || 7200) * 1000 - 5 * 60 * 1000,
+    };
+
+    return this.tokenCache.token;
+  }
+
+  /**
+   * 添加表情回应
+   * @param messageId 消息 ID
+   * @param emojiType 表情类型（如 'SMILE'）
+   * @returns reactionId 或空字符串（失败时）
+   */
+  async addReaction(messageId: string, emojiType: string): Promise<AddReactionResult> {
+    try {
+      const token = await this.getAccessToken();
+
+      const response = await fetch(
+        `https://open.feishu.cn/open-apis/im/v1/messages/${messageId}/reactions`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ reaction_type: { emoji_type: emojiType } }),
+        }
+      );
+
+      const data: FeishuApiResponse = await response.json();
+
+      if (data.code !== 0) {
+        console.warn(`添加表情回应失败: ${data.msg || `code ${data.code}`}`);
+        return { reactionId: '' };
+      }
+
+      return { reactionId: data.data?.reaction_id || '' };
+    } catch (error) {
+      console.warn('添加表情回应异常:', error);
+      return { reactionId: '' };
+    }
+  }
+
+  /**
+   * 删除表情回应
+   * @param messageId 消息 ID
+   * @param reactionId 表情回应 ID
+   * @returns 是否成功
+   */
+  async deleteReaction(messageId: string, reactionId: string): Promise<boolean> {
+    try {
+      const token = await this.getAccessToken();
+
+      const response = await fetch(
+        `https://open.feishu.cn/open-apis/im/v1/messages/${messageId}/reactions/${reactionId}`,
+        {
+          method: 'DELETE',
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      const data: FeishuApiResponse = await response.json();
+
+      if (data.code !== 0) {
+        console.warn(`删除表情回应失败: ${data.msg || `code ${data.code}`}`);
+        return false;
+      }
+
+      return true;
+    } catch (error) {
+      console.warn('删除表情回应异常:', error);
+      return false;
+    }
+  }
+
+  /**
+   * 便捷方法：添加"正在处理"表情回应
+   * 使用 SMILE 表情
+   */
+  async addProcessingReaction(messageId: string): Promise<AddReactionResult> {
+    return this.addReaction(messageId, 'SMILE');
+  }
+
+  /**
+   * 清空 token 缓存
+   */
+  clearTokenCache(): void {
+    this.tokenCache = null;
+  }
+}

--- a/src/channels/feishu-websocket.ts
+++ b/src/channels/feishu-websocket.ts
@@ -66,6 +66,7 @@ export class FeishuWebSocket {
 
     const eventDispatcher = new Lark.EventDispatcher({}).register({
       'im.message.receive_v1': async (data: any) => {
+        console.log('[WebSocket] 收到 im.message.receive_v1 事件:', JSON.stringify(data, null, 2));
         this.handleMessage(data);
       },
     });

--- a/src/channels/feishu.ts
+++ b/src/channels/feishu.ts
@@ -6,6 +6,7 @@ import type { MiniclawGateway } from '../core/gateway/index.js';
 import { FeishuClient } from './feishu-client.js';
 import { FeishuWebSocket } from './feishu-websocket.js';
 import { MessageDeduplicator } from './feishu-dedup.js';
+import { FeishuReactions } from './feishu-reactions.js';
 
 /**
  * 飞书配置
@@ -27,6 +28,7 @@ export class FeishuChannel {
   private client: FeishuClient;
   private websocket: FeishuWebSocket;
   private deduplicator: MessageDeduplicator;
+  private reactions: FeishuReactions;
 
   constructor(gateway: MiniclawGateway) {
     const config = gateway.getConfig();
@@ -41,6 +43,7 @@ export class FeishuChannel {
     this.client = new FeishuClient(this.config);
     this.websocket = new FeishuWebSocket(this.config, this.client);
     this.deduplicator = new MessageDeduplicator({ maxSize: 10000 });
+    this.reactions = new FeishuReactions(this.config);
 
     // 设置消息回调
     this.websocket.onMessage(this.handleMessage.bind(this));
@@ -110,22 +113,35 @@ export class FeishuChannel {
       return;
     }
 
-    // 调用 Gateway 处理
-    const response = await this.gateway.handleMessage({
-      channel: 'feishu',
-      userId: event.senderId,
-      groupId: event.chatType === 'group' ? event.chatId : undefined,
-      content: event.content,
-    });
+    // 添加表情回应，表示正在处理
+    const reactionResult = await this.reactions.addProcessingReaction(event.messageId);
+    const reactionId = reactionResult.reactionId;
 
-    // 发送回复
-    if (response.content) {
-      await this.client.sendMessage({
-        receiveId: event.chatType === 'p2p' ? event.senderId : event.chatId,
-        msgType: 'text',
-        content: response.content,
-        replyToMessageId: event.rootId, // 群聊话题回复
+    try {
+      // 调用 Gateway 处理
+      const response = await this.gateway.handleMessage({
+        channel: 'feishu',
+        userId: event.senderId,
+        groupId: event.chatType === 'group' ? event.chatId : undefined,
+        content: event.content,
       });
+
+      // 发送回复
+      if (response.content) {
+        const receiveIdType = event.chatType === 'p2p' ? 'open_id' : 'chat_id';
+        await this.client.sendMessage({
+          receiveId: event.chatType === 'p2p' ? event.senderId : event.chatId,
+          receiveIdType,
+          msgType: 'post', // 使用富文本消息，与 OpenClaw 一致
+          content: response.content,
+          replyToMessageId: event.rootId, // 群聊话题回复
+        });
+      }
+    } finally {
+      // 处理完成后删除表情回应
+      if (reactionId) {
+        await this.reactions.deleteReaction(event.messageId, reactionId);
+      }
     }
   }
 }

--- a/tests/unit/channels/feishu-client.test.ts
+++ b/tests/unit/channels/feishu-client.test.ts
@@ -127,7 +127,7 @@ describe('FeishuClient', () => {
 
       expect(result.messageId).toBe('om_test123');
       expect(mockFetch).toHaveBeenCalledWith(
-        'https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=user_id',
+        'https://open.feishu.cn/open-apis/im/v1/messages?receive_id_type=open_id',
         expect.objectContaining({
           method: 'POST',
           headers: expect.objectContaining({

--- a/tests/unit/channels/feishu-reactions.test.ts
+++ b/tests/unit/channels/feishu-reactions.test.ts
@@ -1,0 +1,212 @@
+/**
+ * 飞书表情回应测试
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { FeishuReactions } from '../../../src/channels/feishu-reactions.js';
+
+// Mock fetch
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+describe('FeishuReactions', () => {
+  const config = {
+    appId: 'cli_test',
+    appSecret: 'test_secret',
+  };
+
+  let reactions: FeishuReactions;
+
+  beforeEach(() => {
+    reactions = new FeishuReactions(config);
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('创建表情回应', () => {
+    // 获取 token
+    beforeEach(async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 0,
+          tenant_access_token: 't-test-token',
+          expire: 7200,
+        }),
+      });
+      await reactions.getAccessToken();
+      mockFetch.mockReset();
+    });
+
+    // 成功添加表情回应
+    it('should add reaction to message', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 0,
+          data: { reaction_id: 'rm_test123' },
+        }),
+      });
+
+      const result = await reactions.addReaction('om_msg123', 'SMILE');
+
+      expect(result.reactionId).toBe('rm_test123');
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://open.feishu.cn/open-apis/im/v1/messages/om_msg123/reactions',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer t-test-token',
+          }),
+          body: JSON.stringify({ reaction_type: { emoji_type: 'SMILE' } }),
+        })
+      );
+    });
+
+    // 表情回应失败不应抛出错误（静默失败）
+    it('should not throw error when add reaction fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 230001,
+          msg: 'reaction failed',
+        }),
+      });
+
+      // 不应抛出错误，返回空 reactionId
+      const result = await reactions.addReaction('om_msg123', 'SMILE');
+      expect(result.reactionId).toBe('');
+    });
+
+    // 网络错误时静默失败
+    it('should handle network error gracefully', async () => {
+      mockFetch.mockRejectedValueOnce(new Error('Network error'));
+
+      const result = await reactions.addReaction('om_msg123', 'SMILE');
+      expect(result.reactionId).toBe('');
+    });
+  });
+
+  describe('删除表情回应', () => {
+    beforeEach(async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 0,
+          tenant_access_token: 't-test-token',
+          expire: 7200,
+        }),
+      });
+      await reactions.getAccessToken();
+      mockFetch.mockReset();
+    });
+
+    // 成功删除表情回应
+    it('should delete reaction', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 0,
+        }),
+      });
+
+      const success = await reactions.deleteReaction('om_msg123', 'rm_test123');
+      expect(success).toBe(true);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'https://open.feishu.cn/open-apis/im/v1/messages/om_msg123/reactions/rm_test123',
+        expect.objectContaining({
+          method: 'DELETE',
+          headers: expect.objectContaining({
+            Authorization: 'Bearer t-test-token',
+          }),
+        })
+      );
+    });
+
+    // 删除失败静默处理
+    it('should return false when delete fails', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 230001,
+          msg: 'delete failed',
+        }),
+      });
+
+      const success = await reactions.deleteReaction('om_msg123', 'rm_test123');
+      expect(success).toBe(false);
+    });
+  });
+
+  describe('便捷方法', () => {
+    beforeEach(async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 0,
+          tenant_access_token: 't-test-token',
+          expire: 7200,
+        }),
+      });
+      await reactions.getAccessToken();
+      mockFetch.mockReset();
+    });
+
+    // addProcessingReaction 便捷方法
+    it('should add processing reaction with SMILE emoji', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          code: 0,
+          data: { reaction_id: 'rm_smile123' },
+        }),
+      });
+
+      const result = await reactions.addProcessingReaction('om_msg123');
+      expect(result.reactionId).toBe('rm_smile123');
+    });
+  });
+
+  describe('token 管理', () => {
+    // token 缓存
+    it('should cache token', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          code: 0,
+          tenant_access_token: 't-cached-token',
+          expire: 7200,
+        }),
+      });
+
+      const token1 = await reactions.getAccessToken();
+      const token2 = await reactions.getAccessToken();
+
+      expect(token1).toBe('t-cached-token');
+      expect(token2).toBe('t-cached-token');
+      // API 只调用一次（token 缓存）
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    // 清空缓存
+    it('should clear token cache', async () => {
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          code: 0,
+          tenant_access_token: 't-new-token',
+          expire: 7200,
+        }),
+      });
+
+      await reactions.getAccessToken();
+      reactions.clearTokenCache();
+      const token = await reactions.getAccessToken();
+
+      expect(token).toBe('t-new-token');
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
+});


### PR DESCRIPTION
## 功能

收到飞书消息后，给用户消息添加表情回应（SMILE），表示正在处理。

## 实现内容

1. **FeishuReactions 类**：实现飞书表情回应 API
   - addReaction: 添加表情回应
   - deleteReaction: 删除表情回应
   - addProcessingReaction: 便捷方法，使用 SMILE 表情

2. **FeishuChannel 集成**：
   - 收到消息后添加表情回应
   - 处理完成后删除表情回应

3. **其他修复**：
   - 使用富文本消息 msg_type=post（与 OpenClaw 一致）
   - receive_id_type 默认使用 open_id

## 测试

793 个测试通过 ✅