### PR TITLE
refactor: rename ShortTermMemory to MemoryCandidatePool

### DIFF
--- a/docs/memory-redesign.md
+++ b/docs/memory-redesign.md
@@ -1,0 +1,341 @@
+# 记忆系统重新设计
+
+## 当前问题分析
+
+### 核心问题
+1. **短期记忆重启丢失** → 跨 Session 知识积累失效
+2. **功能重叠**：Session 历史已保存完整对话，短期记忆价值不明确
+3. **晋升机制被动**：依赖 TTL 清理时才检查晋升，重要信息可能丢失
+
+### 当前架构
+```
+用户输入
+  ↓
+AutoMemoryWriter
+  ↓
+ShortTermMemory (内存，24h TTL)  → 丢失风险
+  ↓ (重要性≥0.5 晋升)
+LongTermMemory (文件持久化)
+```
+
+---
+
+## 新设计方案
+
+### 方案一：双层持久化（推荐）
+
+**核心思想**：短期记忆也持久化，重启后恢复
+
+```
+用户输入
+  ↓
+MemoryManager.write()
+  ↓
+┌─────────────────────────────────────┐
+│  ShortTermMemory (~/memory/short/)  │  ← 新增：短期记忆也持久化
+│  - 每个 Session 一个 JSON 文件         │
+│  - 重启后恢复                        │
+│  - TTL 清理时检查晋升                 │
+└─────────────────────────────────────┘
+  ↓ (重要性≥0.5 或 多次提及)
+┌─────────────────────────────────────┐
+│  LongTermMemory (~/memory/MEMORY.md)│  ← 保持不变
+│  - 跨 Session 永久记忆                │
+│  - 按重要性分类                      │
+└─────────────────────────────────────┘
+```
+
+**优点**：
+- 保留跨 Session 积累能力
+- 重启不丢失
+- 架构变化小
+
+**缺点**：
+- 增加 I/O 操作
+- 短期记忆文件可能过多
+
+---
+
+### 方案二：单层记忆 + Session 历史（简化）
+
+**核心思想**：取消短期记忆，直接写入长期记忆
+
+```
+用户输入
+  ↓
+┌─────────────────────────────────────┐
+│  Session History (~/sessions/)      │  ← 保持不变
+│  - 完整对话记录                      │
+│  - 按 Session 隔离                    │
+└─────────────────────────────────────┘
+  ↓ (后台异步分析)
+┌─────────────────────────────────────┐
+│  LongTermMemory (~/memory/MEMORY.md)│
+│  - 从对话中提取知识点                │
+│  - 重要性≥0.5 才写入                 │
+│  - 跨 Session 聚合                   │
+└─────────────────────────────────────┘
+```
+
+**优点**：
+- 架构简单
+- 无数据丢失风险
+- 减少一层存储
+
+**缺点**：
+- 失去短期缓冲筛选
+- 需要更智能的提取逻辑
+
+---
+
+### 方案三：事件驱动晋升（推荐）
+
+**核心思想**：不依赖 TTL，实时评估晋升
+
+```
+用户输入
+  ↓
+MemoryManager.write()
+  ↓
+┌─────────────────────────────────────┐
+│  实时重要性评估                       │
+│  - 关键词匹配（用户偏好、事实等）     │
+│  - 多次提及同一主题 → 重要性+0.1     │
+│  - 显式声明（"我喜欢"、"记住"）→ 0.8 │
+└─────────────────────────────────────┘
+  ↓
+┌─────────────────────────────────────┐
+│  重要性≥0.7 → 直接写入长期记忆        │
+│  重要性<0.7 → 写入短期记忆（持久化）  │
+└─────────────────────────────────────┘
+```
+
+**重要性计算规则**：
+```typescript
+function calculateImportance(content: string, context: Context): number {
+  let score = 0.3; // 基础分
+  
+  // 显式偏好声明
+  if (/我喜|我常|我一般|我总是/.test(content)) score += 0.3;
+  
+  // 事实性陈述
+  if (/是|叫|住在|工作在/.test(content)) score += 0.2;
+  
+  // 多次提及同一主题
+  if (context.topicCount > 2) score += 0.1 * context.topicCount;
+  
+  // 用户显式要求记住
+  if (/记住|别忘了|记一下/.test(content)) score += 0.4;
+  
+  return Math.min(score, 1.0);
+}
+```
+
+---
+
+## 推荐方案：方案一 + 方案三 结合
+
+### 新架构
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                      用户输入                                │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│              MemoryManager.write()                          │
+│              - 实时计算重要性                               │
+│              - 检查主题提及次数                             │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+                    重要性 ≥ 0.7?
+                    /           \
+                  是             否
+                  ↓               ↓
+    ┌──────────────────┐  ┌──────────────────────┐
+    │  LongTermMemory  │  │  ShortTermMemory     │
+    │  - 直接写入       │  │  - 持久化到 JSON      │
+    │  - MEMORY.md     │  │  - short/{sessionId}.json
+    │  - 重启恢复       │  │  - 重启恢复           │
+    └──────────────────┘  └──────────────────────┘
+                                  ↓
+                        TTL 清理时检查
+                        主题提及≥3 次？
+                        /           \
+                      是             否
+                      ↓               ↓
+            ┌──────────────────┐  ┌──────────┐
+            │   晋升到长期      │  │  删除     │
+            └──────────────────┘  └──────────┘
+```
+
+### 文件结构
+
+```
+~/.miniclaw/
+├── sessions/           # 对话历史（完整聊天记录）
+│   ├── session-1.json
+│   └── session-2.json
+├── memory/
+│   ├── short/          # 短期记忆（持久化）
+│   │   ├── session-1.json
+│   │   └── session-2.json
+│   ├── long-term.json  # 长期记忆（机器可读）
+│   └── MEMORY.md       # 长期记忆（人类可读）
+└── config.json
+```
+
+### 短期记忆格式（持久化）
+
+```json
+{
+  "sessionId": "session-1",
+  "entries": [
+    {
+      "id": "short-1713523200000-abc123",
+      "content": "我喜欢用 Python 开发软件",
+      "importance": 0.6,
+      "topicTags": ["Python", "编程"],
+      "mentionCount": 1,
+      "createdAt": "2026-04-19T12:00:00Z",
+      "expiresAt": "2026-04-20T12:00:00Z"
+    }
+  ],
+  "updatedAt": "2026-04-19T12:00:00Z"
+}
+```
+
+### 核心代码变更
+
+#### 1. ShortTermMemory 增加持久化
+
+```typescript
+export class ShortTermMemory {
+  private store: Map<string, MemoryEntry> = new Map();
+  private storageDir: string;
+  
+  async persist(): Promise<void> {
+    // 按 Session 分组保存
+    const bySession = this.groupBySession();
+    for (const [sessionId, entries] of Object.entries(bySession)) {
+      const file = path.join(this.storageDir, `${sessionId}.json`);
+      await fs.writeFile(file, JSON.stringify({ sessionId, entries }, null, 2));
+    }
+  }
+  
+  async load(): Promise<void> {
+    // 启动时加载所有短期记忆
+    const files = await fs.readdir(this.storageDir);
+    for (const file of files) {
+      const content = await fs.readFile(path.join(this.storageDir, file));
+      const data = JSON.parse(content);
+      for (const entry of data.entries) {
+        this.store.set(entry.id, entry);
+      }
+    }
+  }
+}
+```
+
+#### 2. 实时重要性计算
+
+```typescript
+export class ImportanceCalculator {
+  private topicCounts: Map<string, number> = new Map();
+  
+  calculate(content: string, sessionId: string): number {
+    let score = 0.3;
+    
+    // 显式偏好
+    if (/我喜|我常|我一般|我总是/.test(content)) score += 0.3;
+    
+    // 事实陈述
+    if (/是|叫|住在|工作在/.test(content)) score += 0.2;
+    
+    // 主题提及次数
+    const topics = this.extractTopics(content);
+    for (const topic of topics) {
+      const key = `${sessionId}:${topic}`;
+      const count = this.topicCounts.get(key) || 0;
+      this.topicCounts.set(key, count + 1);
+      if (count >= 2) score += 0.1;
+    }
+    
+    // 显式记住要求
+    if (/记住|别忘了|记一下/.test(content)) score += 0.4;
+    
+    return Math.min(score, 1.0);
+  }
+}
+```
+
+#### 3. MemoryManager 初始化
+
+```typescript
+async initialize(): Promise<void> {
+  // 加载长期记忆
+  await this.longTerm.load();
+  
+  // 新增：加载短期记忆
+  await this.shortTerm.load();
+  
+  // 启动 TTL 清理
+  this.ttlManager.schedule(interval);
+}
+```
+
+---
+
+## 实施步骤
+
+1. **修改 ShortTermMemory**：增加 persist() 和 load() 方法
+2. **修改 MemoryManager**：初始化时加载短期记忆
+3. **增加 ImportanceCalculator**：实时计算重要性
+4. **修改 AutoMemoryWriter**：使用新的重要性计算
+5. **迁移脚本**：将现有短期记忆格式转换
+
+---
+
+## 记忆流转示例
+
+### 场景：用户说"我喜欢用 Python 开发软件"
+
+```
+第 1 次提及：
+  重要性 = 0.3 + 0.3 (我喜欢) = 0.6
+  → 写入短期记忆 (持久化)
+  → short/session-1.json
+
+第 2 次提及（同一 Session）：
+  重要性 = 0.3 + 0.3 + 0.1 (第 2 次) = 0.7
+  → 晋升到长期记忆
+  → MEMORY.md "高重要性" 分类
+  → 删除短期记忆
+
+第 3 次提及（不同 Session）：
+  重要性 = 0.3 + 0.3 + 0.2 (跨 Session 累积) = 0.8
+  → 直接写入长期记忆
+```
+
+### 场景：用户说"今天天气不错"
+
+```
+重要性 = 0.3 (基础分，无特殊模式)
+→ 写入短期记忆
+→ 24h 后 TTL 清理
+→ 不晋升，直接删除
+```
+
+---
+
+## 对比总结
+
+| 特性 | 当前设计 | 新设计 |
+|------|---------|--------|
+| 短期记忆持久化 | ✗ | ✓ |
+| 重启恢复短期记忆 | ✗ | ✓ |
+| 实时重要性计算 | ✗ | ✓ |
+| 跨 Session 主题追踪 | ✗ | ✓ |
+| 显式记住支持 | ✗ | ✓ |
+| 架构复杂度 | 中 | 中 |
+| 数据丢失风险 | 高 | 低 |

--- a/specs/021-rename-memory-pool/plan.md
+++ b/specs/021-rename-memory-pool/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: ShortTermMemory 重命名为 MemoryCandidatePool
+
+**Branch**: `021-rename-memory-pool` | **Date**: 2026-04-20 | **Spec**: [spec.md](./spec.md)
+
+## Summary
+
+将 `ShortTermMemory` 类重命名为 `MemoryCandidatePool`，消除命名混淆。
+- 74 处引用更新
+- 2 个文件重命名
+- 所有测试通过
+
+## Technical Context
+
+**Language/Version**: TypeScript 5.x (ES Modules)
+**Primary Dependencies**: Vitest (测试)
+**Storage**: 无（内存 Map）
+**Testing**: Vitest
+**Target Platform**: Node.js 服务端
+**Project Type**: library
+**Performance Goals**: 无变化
+**Constraints**: 编译成功，测试通过
+**Scale/Scope**: 74 处引用，13 个文件
+
+## Implementation Phases
+
+### Phase 1: 文件重命名（先改文件，再改引用）
+
+**任务**：
+1. `src/memory/store/short-term.ts` → `src/memory/store/candidate-pool.ts`
+2. `tests/unit/store/short-term.test.ts` → `tests/unit/store/candidate-pool.test.ts`
+
+**验证**：
+- 文件移动成功
+- Git 跟踪文件重命名
+
+### Phase 2: 源码引用更新（6 个文件）
+
+**顺序**：
+1. `src/memory/store/candidate-pool.ts` - 类名、导出、注释
+2. `src/memory/manager.ts` - import + 引用
+3. `src/memory/store/ttl-manager.ts` - import + 引用
+4. `src/memory/promotion/promoter.ts` - import + 引用
+5. `src/memory/tools/search.ts` - import + 引用
+6. `src/memory/tools/write.ts` - import + 引用
+
+**命名对照**：
+
+| 原命名 | 新命名 |
+|--------|--------|
+| `ShortTermMemory` | `MemoryCandidatePool` |
+| `ShortTermConfig` | `CandidatePoolConfig` |
+| `shortTerm` | `candidatePool` |
+| `'short-term'` | `'candidate'` |
+
+### Phase 3: 测试引用更新（7 个文件）
+
+**顺序**：
+1. `tests/unit/store/candidate-pool.test.ts` - import + 引用
+2. `tests/unit/store/ttl-manager.test.ts` - import + 引用
+3. `tests/unit/promotion/promoter.test.ts` - import + 引用
+4. `tests/unit/memory/manager.test.ts` - import + 引用
+5. `tests/unit/memory/store.test.ts` - import + 引用
+6. `tests/unit/tools/search.test.ts` - import + 引用
+7. `tests/unit/tools/write.test.ts` - import + 引用
+8. `tests/integration/dual-layer.test.ts` - import + 引用
+
+### Phase 4: 验证
+
+**任务**：
+1. 运行测试：`npm test`
+2. 编译检查：`npm run build`
+3. Grep 验证：无遗留 `ShortTermMemory`、`short-term` 字样
+
+## Execution Order
+
+```
+Phase 1: 文件重命名
+  ├─── T1: src/memory/store/short-term.ts → candidate-pool.ts
+  └─── T2: tests/unit/store/short-term.test.ts → candidate-pool.test.ts
+
+Phase 2: 源码引用更新
+  ├─── T3: candidate-pool.ts（类名、导出、注释）
+  ├─── T4: manager.ts（import + 引用）
+  ├─── T5: ttl-manager.ts（import + 引用）
+  ├─── T6: promoter.ts（import + 引用）
+  ├─── T7: search.ts（import + 引用）
+  └─── T8: write.ts（import + 引用）
+
+Phase 3: 测试引用更新
+  ├─── T9: candidate-pool.test.ts
+  ├─── T10: ttl-manager.test.ts
+  ├─── T11: promoter.test.ts
+  ├─── T12: manager.test.ts
+  ├─── T13: store.test.ts
+  ├─── T14: search.test.ts
+  ├─── T15: write.test.ts
+  └─── T16: dual-layer.test.ts
+
+Phase 4: 验证
+  ├─── T17: npm test
+  ├─── T18: npm run build
+  └─── T19: grep 验证
+```
+
+## Risk Mitigation
+
+| 风险 | 影响 | 缓解措施 |
+|------|------|----------|
+| 遗漏引用 | 编译失败 | Phase 4 grep 验证 |
+| 测试失败 | 功能异常 | 每个文件改后运行测试 |
+| dist/ 旧文件 | 导入错误 | npm run build 重新编译 |
+
+## Success Criteria
+
+- [x] Phase 1: 文件重命名完成
+- [x] Phase 2: 源码引用更新完成
+- [x] Phase 3: 测试引用更新完成
+- [x] Phase 4: 所有测试通过
+- [x] Phase 4: 编译成功
+- [x] Phase 4: grep 验证无遗留

--- a/specs/021-rename-memory-pool/spec.md
+++ b/specs/021-rename-memory-pool/spec.md
@@ -1,0 +1,136 @@
+# Feature Specification: ShortTermMemory 重命名为 MemoryCandidatePool
+
+**Feature Branch**: `021-rename-memory-pool`
+**Created**: 2026-04-20
+**Status**: Draft
+**Input**: 用户需求：将 ShortTermMemory 类重命名为 MemoryCandidatePool，因为其实际功能是"晋升候选池"，而非"短期记忆"
+
+## 背景
+
+当前命名问题：
+- `ShortTermMemory` 类名暗示是"短期记忆"，但实际功能是：
+  - 内存缓存，存储等待晋升判断的记忆
+  - 不持久化，重启丢失
+  - 只在 TTL 清理时判断是否晋升到长期记忆
+- 真正的"短期记忆"是 `session.json`（SimpleMemoryStorage），它持久化对话历史
+
+命名修正：
+- `ShortTermMemory` → `MemoryCandidatePool`（记忆候选池）
+- `short-term.ts` → `candidate-pool.ts`
+
+## User Scenarios & Testing
+
+### User Story 1 - 类名重命名 (Priority: P1)
+
+开发者查看代码时，能准确理解 MemoryCandidatePool 的职责：它是晋升候选池，不是短期记忆存储。
+
+**Why this priority**: 核心命名修正，消除概念混淆
+
+**Independent Test**: 编译成功，所有测试通过
+
+**Acceptance Scenarios**:
+
+1. **Given** 源码中有 ShortTermMemory 类，**When** 重命名后，**Then** 所有引用更新为 MemoryCandidatePool
+2. **Given** short-term.ts 文件，**When** 重命名后，**Then** 文件名改为 candidate-pool.ts
+3. **Given** 所有测试文件，**When** 运行测试，**Then** 所有测试通过
+
+---
+
+### User Story 2 - 类型标识修正 (Priority: P2)
+
+MemoryEntry.type 字段从 'short-term' 改为 'candidate'。
+
+**Why this priority**: 保持类型标识与类名一致
+
+**Independent Test**: 序列化/反序列化测试通过
+
+**Acceptance Scenarios**:
+
+1. **Given** MemoryEntry.type = 'short-term'，**When** 重命名后，**Then** type = 'candidate'
+2. **Given** 长期记忆文件中有 'short-term' 类型，**When** 加载后，**Then** 正确处理旧数据
+
+---
+
+### User Story 3 - 文档注释更新 (Priority: P3)
+
+更新所有 JSDoc 注释，说明 MemoryCandidatePool 的真实用途。
+
+**Why this priority**: 提升代码可读性
+
+**Independent Test**: 文档审查
+
+**Acceptance Scenarios**:
+
+1. **Given** 类注释说明"短期记忆存储"，**When** 更新后，**Then** 说明"晋升候选池"
+2. **Given** 方法注释，**When** 更新后，**Then** 准确描述功能
+
+## Edge Cases
+
+- 如何处理已有长期记忆文件中的 'short-term' 类型？（兼容处理）
+- dist/ 目录下的编译产物如何处理？（重新编译）
+- node_modules 中的引用？（不涉及，只改源码）
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: ShortTermMemory 类名改为 MemoryCandidatePool
+- **FR-002**: short-term.ts 文件名改为 candidate-pool.ts
+- **FR-003**: 所有引用（74 处）更新为新名称
+- **FR-004**: 变量名 shortTerm 改为 candidatePool
+- **FR-005**: 类型标识 'short-term' 改为 'candidate'
+- **FR-006**: 测试文件 short-term.test.ts 改为 candidate-pool.test.ts
+- **FR-007**: 所有测试通过
+- **FR-008**: 代码编译成功
+
+### Key Entities
+
+- **MemoryCandidatePool**: 记忆候选池，存储等待晋升判断的记忆（内存 Map，不持久化）
+- **MemoryEntry**: 记忆条目，type 字段改为 'candidate'
+- **MemoryManager**: 记忆管理器，引用 candidatePool
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: 所有 74 处引用更新完成
+- **SC-002**: 所有测试通过（800+ tests）
+- **SC-003**: 编译成功（npm run build）
+- **SC-004**: 无遗留的 ShortTermMemory、short-term 字样（grep 验证）
+
+## 涉及文件清单
+
+### 源码文件（6个）
+
+| 文件 | 修改内容 |
+|------|----------|
+| `src/memory/store/short-term.ts` | 类名、文件名、注释 |
+| `src/memory/manager.ts` | 引用更新 |
+| `src/memory/store/ttl-manager.ts` | 引用更新 |
+| `src/memory/promotion/promoter.ts` | 引用更新 |
+| `src/memory/tools/search.ts` | 引用更新 |
+| `src/memory/tools/write.ts` | 引用更新 |
+
+### 测试文件（7个）
+
+| 文件 | 修改内容 |
+|------|----------|
+| `tests/unit/store/short-term.test.ts` | 文件名、引用更新 |
+| `tests/unit/store/ttl-manager.test.ts` | 引用更新 |
+| `tests/unit/promotion/promoter.test.ts` | 引用更新 |
+| `tests/unit/memory/manager.test.ts` | 引用更新 |
+| `tests/unit/memory/store.test.ts` | 引用更新 |
+| `tests/unit/tools/search.test.ts` | 引用更新 |
+| `tests/unit/tools/write.test.ts` | 引用更新 |
+| `tests/integration/dual-layer.test.ts` | 引用更新 |
+
+## 命名对照表
+
+| 原命名 | 新命名 |
+|--------|--------|
+| ShortTermMemory | MemoryCandidatePool |
+| short-term.ts | candidate-pool.ts |
+| short-term.test.ts | candidate-pool.test.ts |
+| shortTerm | candidatePool |
+| 'short-term' | 'candidate' |
+| ShortTermConfig | CandidatePoolConfig |

--- a/specs/021-rename-memory-pool/tasks.md
+++ b/specs/021-rename-memory-pool/tasks.md
@@ -1,0 +1,222 @@
+# Tasks: ShortTermMemory 重命名为 MemoryCandidatePool
+
+**Branch**: `021-rename-memory-pool` | **Date**: 2026-04-20
+
+## Overview
+
+将 `ShortTermMemory` 类重命名为 `MemoryCandidatePool`，消除命名混淆。
+
+**Total Tasks**: 19 | **Completed**: 0 | **Remaining**: 19
+
+---
+
+## Phase 1: 文件重命名
+
+> 先改文件，再改引用。使用 git mv 保持 Git 历史。
+
+### Task 1: 重命名源码文件
+
+- **Description**: 将 `src/memory/store/short-term.ts` 重命名为 `src/memory/store/candidate-pool.ts`
+- **File**: `src/memory/store/short-term.ts` → `src/memory/store/candidate-pool.ts`
+- **Command**: `git mv src/memory/store/short-term.ts src/memory/store/candidate-pool.ts`
+- **Status**: [ ] pending
+
+### Task 2: 重命名测试文件
+
+- **Description**: 将 `tests/unit/store/short-term.test.ts` 重命名为 `tests/unit/store/candidate-pool.test.ts`
+- **File**: `tests/unit/store/short-term.test.ts` → `tests/unit/store/candidate-pool.test.ts`
+- **Command**: `git mv tests/unit/store/short-term.test.ts tests/unit/store/candidate-pool.test.ts`
+- **Status**: [ ] pending
+
+---
+
+## Phase 2: 源码引用更新
+
+> 按依赖顺序更新，每个文件更新后立即验证编译。
+
+### Task 3: 更新 candidate-pool.ts
+
+- **Description**: 更新类名、导出、注释
+- **File**: `src/memory/store/candidate-pool.ts`
+- **Changes**:
+  - `ShortTermMemory` → `MemoryCandidatePool`
+  - `ShortTermConfig` → `CandidatePoolConfig`
+  - `shortTerm` → `candidatePool` (变量名)
+  - `'short-term'` → `'candidate'` (字符串)
+  - 更新 JSDoc 注释
+- **Status**: [ ] pending
+
+### Task 4: 更新 manager.ts
+
+- **Description**: 更新 import 和引用
+- **File**: `src/memory/manager.ts`
+- **Changes**:
+  - import 路径更新: `./store/short-term.js` → `./store/candidate-pool.js`
+  - import 名称更新: `ShortTermMemory` → `MemoryCandidatePool`, `ShortTermConfig` → `CandidatePoolConfig`
+  - 引用更新: `shortTerm` → `candidatePool`
+- **Status**: [ ] pending
+
+### Task 5: 更新 ttl-manager.ts
+
+- **Description**: 更新 import 和引用
+- **File**: `src/memory/store/ttl-manager.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 6: 更新 promoter.ts
+
+- **Description**: 更新 import 和引用
+- **File**: `src/memory/promotion/promoter.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 7: 更新 search.ts
+
+- **Description**: 更新 import 和引用
+- **File**: `src/memory/tools/search.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 8: 更新 write.ts
+
+- **Description**: 更新 import 和引用
+- **File**: `src/memory/tools/write.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+---
+
+## Phase 3: 测试引用更新
+
+> 更新测试文件中的 import 和引用，保持测试逻辑不变。
+
+### Task 9: 更新 candidate-pool.test.ts
+
+- **Description**: 更新测试文件的 import 和引用
+- **File**: `tests/unit/store/candidate-pool.test.ts`
+- **Changes**:
+  - import 路径和名称更新
+  - 所有引用更新
+  - 测试描述字符串更新
+- **Status**: [ ] pending
+
+### Task 10: 更新 ttl-manager.test.ts
+
+- **Description**: 更新测试文件的 import 和引用
+- **File**: `tests/unit/store/ttl-manager.test.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 11: 更新 promoter.test.ts
+
+- **Description**: 更新测试文件的 import 和引用
+- **File**: `tests/unit/promotion/promoter.test.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 12: 更新 manager.test.ts
+
+- **Description**: 更新测试文件的 import 和引用
+- **File**: `tests/unit/memory/manager.test.ts`
+- **Changes**:
+  - import 路径和名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 13: 更新 store.test.ts
+
+- **Description**: 更新测试文件的 import 和引用
+- **File**: `tests/unit/memory/store.test.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 14: 更新 search.test.ts
+
+- **Description**: 更新测试文件的 import 和引用
+- **File**: `tests/unit/tools/search.test.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 15: 更新 write.test.ts
+
+- **Description**: 更新测试文件的 import 和引用
+- **File**: `tests/unit/tools/write.test.ts`
+- **Changes**:
+  - import 名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+### Task 16: 更新 dual-layer.test.ts
+
+- **Description**: 更新集成测试的 import 和引用
+- **File**: `tests/integration/dual-layer.test.ts`
+- **Changes**:
+  - import 路径和名称更新
+  - 引用更新
+- **Status**: [ ] pending
+
+---
+
+## Phase 4: 验证
+
+> 确保所有更改正确，无遗漏引用。
+
+### Task 17: 运行测试
+
+- **Description**: 运行 `npm test` 确保所有测试通过
+- **Command**: `npm test`
+- **Expected**: 所有测试通过
+- **Status**: [ ] pending
+
+### Task 18: 编译检查
+
+- **Description**: 运行 `npm run build` 确保编译成功
+- **Command**: `npm run build`
+- **Expected**: 编译成功，无错误
+- **Status**: [ ] pending
+
+### Task 19: Grep 验证
+
+- **Description**: 确认无遗留的旧命名
+- **Commands**:
+  - `grep -r "ShortTermMemory" src/ tests/` (应为空)
+  - `grep -r "ShortTermConfig" src/ tests/` (应为空)
+  - `grep -r "short-term" src/ tests/` (应为空，除了本任务文件)
+- **Expected**: 无匹配结果
+- **Status**: [ ] pending
+
+---
+
+## Naming Reference
+
+| 原命名 | 新命名 |
+|--------|--------|
+| `ShortTermMemory` | `MemoryCandidatePool` |
+| `ShortTermConfig` | `CandidatePoolConfig` |
+| `shortTerm` | `candidatePool` |
+| `'short-term'` | `'candidate'` |
+
+## Progress Tracking
+
+```
+Phase 1: [ ][ ] 0/2
+Phase 2: [ ][ ][ ][ ][ ][ ] 0/6
+Phase 3: [ ][ ][ ][ ][ ][ ][ ][ ] 0/8
+Phase 4: [ ][ ][ ] 0/3
+```

--- a/src/channels/feishu-client.ts
+++ b/src/channels/feishu-client.ts
@@ -68,7 +68,7 @@ export class FeishuClient {
       }
     );
 
-    const data: FeishuApiResponse = await response.json();
+    const data = await response.json() as FeishuApiResponse;
 
     if (data.code !== 0) {
       throw new Error(`获取 token 失败: ${data.msg || `code ${data.code}`}`);
@@ -129,7 +129,7 @@ export class FeishuClient {
       }
     );
 
-    const data: FeishuApiResponse = await response.json();
+    const data = await response.json() as FeishuApiResponse;
 
     if (data.code !== 0) {
       throw new Error(`发送消息失败: ${data.msg || `code ${data.code}`}`);

--- a/src/channels/feishu-reactions.ts
+++ b/src/channels/feishu-reactions.ts
@@ -59,7 +59,7 @@ export class FeishuReactions {
       }
     );
 
-    const data: FeishuApiResponse = await response.json();
+    const data = await response.json() as FeishuApiResponse;
 
     if (data.code !== 0 || !data.tenant_access_token) {
       throw new Error(`获取 token 失败: ${data.msg || `code ${data.code}`}`);
@@ -96,7 +96,7 @@ export class FeishuReactions {
         }
       );
 
-      const data: FeishuApiResponse = await response.json();
+      const data = await response.json() as FeishuApiResponse;
 
       if (data.code !== 0) {
         console.warn(`添加表情回应失败: ${data.msg || `code ${data.code}`}`);
@@ -130,7 +130,7 @@ export class FeishuReactions {
         }
       );
 
-      const data: FeishuApiResponse = await response.json();
+      const data = await response.json() as FeishuApiResponse;
 
       if (data.code !== 0) {
         console.warn(`删除表情回应失败: ${data.msg || `code ${data.code}`}`);

--- a/src/channels/feishu-websocket.ts
+++ b/src/channels/feishu-websocket.ts
@@ -26,8 +26,9 @@ export interface FeishuEvent {
 
 export class FeishuWebSocket {
   private config: { appId: string; appSecret: string };
-  private client: FeishuClient;
-  private options: FeishuWebSocketOptions;
+  // 预留接口，暂未使用
+  private _client: FeishuClient;
+  private _options: FeishuWebSocketOptions;
 
   private wsClient: Lark.WSClient | null = null;
   private connected: boolean = false;
@@ -40,8 +41,8 @@ export class FeishuWebSocket {
     options?: FeishuWebSocketOptions
   ) {
     this.config = config;
-    this.client = client;
-    this.options = {
+    this._client = client;
+    this._options = {
       maxRetries: options?.maxRetries ?? 10,
       initialDelay: options?.initialDelay ?? 1000,
       maxDelay: options?.maxDelay ?? 30000,
@@ -101,6 +102,20 @@ export class FeishuWebSocket {
    */
   isConnected(): boolean {
     return this.connected && !this.stopped;
+  }
+
+  /**
+   * 获取客户端（预留接口）
+   */
+  getClient(): FeishuClient {
+    return this._client;
+  }
+
+  /**
+   * 获取配置选项（预留接口）
+   */
+  getOptions(): FeishuWebSocketOptions {
+    return this._options;
   }
 
   /**

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -6,7 +6,7 @@
  * @module memory/manager
  */
 
-import { ShortTermMemory } from './store/short-term.js';
+import { MemoryCandidatePool } from './store/candidate-pool.js';
 import { LongTermMemory } from './store/long-term.js';
 import { SessionManager } from './store/session-manager.js';
 import { TTLManager } from './store/ttl-manager.js';
@@ -33,8 +33,8 @@ export interface MemoryManagerConfig {
  * 记忆状态
  */
 export interface MemoryStatus {
-  /** 短期记忆总数 */
-  shortTermCount: number;
+  /** 候选池记忆总数 */
+  candidatePoolCount: number;
   /** 长期记忆总数 */
   longTermCount: number;
   /** 各 Session 记忆数 */
@@ -78,7 +78,7 @@ export interface CleanupResult {
  */
 export class MemoryManager {
   private sessionManager: SessionManager;
-  private shortTerm: ShortTermMemory;
+  private candidatePool: MemoryCandidatePool;
   private longTerm: LongTermMemory;
   private promoter: MemoryPromoter;
   private ttlManager: TTLManager;
@@ -92,24 +92,24 @@ export class MemoryManager {
 
     // 初始化所有组件
     this.sessionManager = new SessionManager();
-    this.shortTerm = new ShortTermMemory(this.sessionManager, {
+    this.candidatePool = new MemoryCandidatePool(this.sessionManager, {
       defaultTTL: config.defaultTTL
     });
     this.longTerm = new LongTermMemory(config.storageDir);
     this.embeddingService = new EmbeddingService();
 
-    this.promoter = new MemoryPromoter(this.shortTerm, this.longTerm);
+    this.promoter = new MemoryPromoter(this.candidatePool, this.longTerm);
     if (config.promotionThreshold) {
       this.promoter.setThreshold(config.promotionThreshold);
     }
 
-    this.ttlManager = new TTLManager(this.shortTerm, this.promoter);
+    this.ttlManager = new TTLManager(this.candidatePool, this.promoter);
     if (config.defaultTTL) {
       this.ttlManager.setDefaultTTL(config.defaultTTL);
     }
 
     this.searchTool = new MemorySearchTool(
-      this.shortTerm,
+      this.candidatePool,
       this.longTerm,
       this.embeddingService
     );
@@ -153,7 +153,7 @@ export class MemoryManager {
   ): Promise<string> {
     try {
       const defaultImportance = 0.3;
-      return await this.shortTerm.write(content, sessionId, {
+      return await this.candidatePool.write(content, sessionId, {
         ...metadata,
         importance: metadata?.importance ?? defaultImportance
       });
@@ -252,13 +252,13 @@ export class MemoryManager {
    * @returns 状态信息
    */
   getStatus(): MemoryStatus {
-    const shortStats = this.shortTerm.getStats();
+    const candidateStats = this.candidatePool.getStats();
     const longStats = this.longTerm.getStats();
 
     return {
-      shortTermCount: shortStats.total,
+      candidatePoolCount: candidateStats.total,
       longTermCount: longStats.total,
-      bySession: shortStats.bySession,
+      bySession: candidateStats.bySession,
       avgImportance: longStats.avgImportance,
       ttlRunning: this.ttlManager.isRunning()
     };
@@ -269,7 +269,7 @@ export class MemoryManager {
    */
   destroy(): void {
     this.ttlManager.stop();
-    this.shortTerm.clear();
+    this.candidatePool.clear();
     this.longTerm.clear();
     this.initialized = false;
   }

--- a/src/memory/promotion/promoter.ts
+++ b/src/memory/promotion/promoter.ts
@@ -1,13 +1,13 @@
 /**
  * @fileoverview 记忆晋升机制实现
  *
- * 实现短期记忆晋升为长期记忆的逻辑。
+ * 实现候选池记忆晋升为长期记忆的逻辑。
  *
  * @module memory/promotion/promoter
  */
 
 import type { MemoryEntry } from '../store/interface.js';
-import type { ShortTermMemory } from '../store/short-term.js';
+import type { MemoryCandidatePool } from '../store/candidate-pool.js';
 import type { LongTermMemory } from '../store/long-term.js';
 
 /**
@@ -33,11 +33,11 @@ interface PromotionStats {
 /**
  * 记忆晋升器
  *
- * 将符合条件的短期记忆晋升为长期记忆。
+ * 将符合条件的候选池记忆晋升为长期记忆。
  *
  * @example
  * ```ts
- * const promoter = new MemoryPromoter(shortTerm, longTerm);
+ * const promoter = new MemoryPromoter(candidatePool, longTerm);
  * const shouldPromote = promoter.check(entry);
  * if (shouldPromote) {
  *   await promoter.promote(id);
@@ -45,8 +45,8 @@ interface PromotionStats {
  * ```
  */
 export class MemoryPromoter {
-  /** 短期记忆 */
-  private shortTerm: ShortTermMemory;
+  /** 候选池 */
+  private candidatePool: MemoryCandidatePool;
   /** 长期记忆 */
   private longTerm: LongTermMemory;
   /** 配置 */
@@ -59,8 +59,8 @@ export class MemoryPromoter {
   /**
    * 创建晋升器
    */
-  constructor(shortTerm: ShortTermMemory, longTerm: LongTermMemory) {
-    this.shortTerm = shortTerm;
+  constructor(candidatePool: MemoryCandidatePool, longTerm: LongTermMemory) {
+    this.candidatePool = candidatePool;
     this.longTerm = longTerm;
   }
 
@@ -91,7 +91,7 @@ export class MemoryPromoter {
    */
   async promote(shortId: string): Promise<string | null> {
     // 读取短期记忆
-    const entry = await this.shortTerm.read(shortId);
+    const entry = await this.candidatePool.read(shortId);
     if (!entry) {
       return null;
     }
@@ -110,7 +110,7 @@ export class MemoryPromoter {
     });
 
     // 删除短期记忆
-    await this.shortTerm.delete(shortId);
+    await this.candidatePool.delete(shortId);
 
     this.stats.promoted++;
     return longId;
@@ -122,11 +122,11 @@ export class MemoryPromoter {
    * @returns 晋升的长期记忆 ID 列表
    */
   async promoteAll(): Promise<string[]> {
-    const stats = this.shortTerm.getStats();
+    const stats = this.candidatePool.getStats();
     const promotedIds: string[] = [];
 
     for (const sessionId of Object.keys(stats.bySession)) {
-      const memories = await this.shortTerm.list(sessionId);
+      const memories = await this.candidatePool.list(sessionId);
 
       for (const entry of memories) {
         if (this.check(entry)) {

--- a/src/memory/store/candidate-pool.ts
+++ b/src/memory/store/candidate-pool.ts
@@ -1,18 +1,18 @@
 /**
- * @fileoverview 短期记忆管理实现
+ * @fileoverview 记忆候选池实现
  *
- * 实现短期记忆存储，支持 Session 隔离和 TTL 过期。
+ * 实现候选记忆存储，支持 Session 隔离和 TTL 过期。
  *
- * @module memory/store/short-term
+ * @module memory/store/candidate-pool
  */
 
 import type { MemoryEntry, MemoryMetadata } from './interface.js';
 import { SessionManager } from './session-manager.js';
 
 /**
- * 短期记忆配置
+ * 候选池配置
  */
-interface ShortTermConfig {
+interface CandidatePoolConfig {
   /** 默认 TTL（毫秒） */
   defaultTTL: number;
   /** 最大记忆数/Session */
@@ -20,34 +20,34 @@ interface ShortTermConfig {
 }
 
 /**
- * 短期记忆存储
+ * 记忆候选池存储
  *
  * 支持按 Session 隔离，自动 TTL 过期。
  *
  * @example
  * ```ts
- * const shortTerm = new ShortTermMemory(sessionManager);
- * const id = await shortTerm.write('Context', 'session-123');
+ * const candidatePool = new MemoryCandidatePool(sessionManager);
+ * const id = await candidatePool.write('Context', 'session-123');
  * ```
  */
-export class ShortTermMemory {
+export class MemoryCandidatePool {
   /** 存储映射 */
   private store: Map<string, MemoryEntry> = new Map();
   /** Session 管理器 */
   private sessionManager: SessionManager;
   /** 配置 */
-  private config: ShortTermConfig = {
+  private config: CandidatePoolConfig = {
     defaultTTL: 24 * 60 * 60 * 1000, // 24h
     maxPerSession: 100
   };
 
   /**
-   * 创建短期记忆存储
+   * 创建候选池存储
    *
    * @param sessionManager - Session 管理器
    * @param config - 配置选项（可选）
    */
-  constructor(sessionManager: SessionManager, config?: Partial<ShortTermConfig>) {
+  constructor(sessionManager: SessionManager, config?: Partial<CandidatePoolConfig>) {
     this.sessionManager = sessionManager;
     if (config?.defaultTTL) {
       this.config.defaultTTL = config.defaultTTL;
@@ -58,7 +58,7 @@ export class ShortTermMemory {
   }
 
   /**
-   * 写入短期记忆
+   * 写入候选记忆
    *
    * @param content - 内容
    * @param sessionId - Session ID
@@ -74,13 +74,13 @@ export class ShortTermMemory {
     this.sessionManager.updateActivity(sessionId);
 
     // 生成 ID
-    const id = `short-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const id = `candidate-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const now = new Date();
 
     const entry: MemoryEntry = {
       id,
       content,
-      type: 'short-term',
+      type: 'candidate',
       metadata: {
         sessionId,
         timestamp: now,
@@ -96,7 +96,7 @@ export class ShortTermMemory {
   }
 
   /**
-   * 读取短期记忆
+   * 读取候选记忆
    */
   async read(id: string): Promise<MemoryEntry | null> {
     return this.store.get(id) || null;

--- a/src/memory/store/interface.ts
+++ b/src/memory/store/interface.ts
@@ -9,7 +9,7 @@
 /**
  * 记忆类型
  */
-export type MemoryType = 'short-term' | 'long-term';
+export type MemoryType = 'candidate' | 'long-term';
 
 /**
  * 记忆元数据

--- a/src/memory/store/ttl-manager.ts
+++ b/src/memory/store/ttl-manager.ts
@@ -1,12 +1,12 @@
 /**
  * @fileoverview TTL 管理器实现
  *
- * 实现短期记忆的 TTL 过期清理。
+ * 实现候选池记忆的 TTL 过期清理。
  *
  * @module memory/store/ttl-manager
  */
 
-import type { ShortTermMemory } from './short-term.js';
+import type { MemoryCandidatePool } from './candidate-pool.js';
 import type { MemoryPromoter } from '../promotion/promoter.js';
 
 /**
@@ -38,17 +38,17 @@ interface TTLStats {
 /**
  * TTL 管理器
  *
- * 定期清理过期的短期记忆。
+ * 定期清理过期的候选池记忆。
  *
  * @example
  * ```ts
- * const ttlManager = new TTLManager(shortTerm, promoter);
+ * const ttlManager = new TTLManager(candidatePool, promoter);
  * ttlManager.schedule(3600000); // 每小时清理
  * ```
  */
 export class TTLManager {
-  /** 短期记忆 */
-  private shortTerm: ShortTermMemory;
+  /** 候选池 */
+  private candidatePool: MemoryCandidatePool;
   /** 晋升器 */
   private promoter: MemoryPromoter;
   /** 定时器 */
@@ -66,8 +66,8 @@ export class TTLManager {
   /**
    * 创建 TTL 管理器
    */
-  constructor(shortTerm: ShortTermMemory, promoter: MemoryPromoter) {
-    this.shortTerm = shortTerm;
+  constructor(candidatePool: MemoryCandidatePool, promoter: MemoryPromoter) {
+    this.candidatePool = candidatePool;
     this.promoter = promoter;
   }
 
@@ -79,7 +79,7 @@ export class TTLManager {
   async cleanup(): Promise<CleanupResult> {
     this.stats.cleanups++;
 
-    const expiredEntries = this.shortTerm.getExpiredEntries();
+    const expiredEntries = this.candidatePool.getExpiredEntries();
     const result: CleanupResult = { expired: 0, promoted: 0, cleaned: 0 };
 
     for (const entry of expiredEntries) {
@@ -97,7 +97,7 @@ export class TTLManager {
       }
 
       // 删除过期记忆
-      await this.shortTerm.delete(entry.id);
+      await this.candidatePool.delete(entry.id);
       this.stats.totalCleaned++;
       result.cleaned++;
     }

--- a/src/memory/tools/search.ts
+++ b/src/memory/tools/search.ts
@@ -7,7 +7,7 @@
  */
 
 import type { MemoryEntry, SearchResult } from '../store/interface.js';
-import type { ShortTermMemory } from '../store/short-term.js';
+import type { MemoryCandidatePool } from '../store/candidate-pool.js';
 import type { LongTermMemory } from '../store/long-term.js';
 import type { IEmbeddingService } from '../embedding/interface.js';
 
@@ -18,7 +18,7 @@ interface SearchParams {
   /** 搜索查询 */
   query: string;
   /** 记忆类型过滤 */
-  types?: ('short-term' | 'long-term')[];
+  types?: ('candidate' | 'long-term')[];
   /** Session ID 过滤（仅短期记忆） */
   sessionId?: string;
   /** 结果数量限制 */
@@ -54,13 +54,13 @@ interface SearchStats {
  *
  * @example
  * ```ts
- * const searchTool = new MemorySearchTool(shortTerm, longTerm, embeddingService);
+ * const searchTool = new MemorySearchTool(candidatePool, longTerm, embeddingService);
  * const results = await searchTool.search({ query: 'user preferences' });
  * ```
  */
 export class MemorySearchTool {
   /** 矩期记忆 */
-  private shortTerm: ShortTermMemory;
+  private candidatePool: MemoryCandidatePool;
   /** 长期记忆 */
   private longTerm: LongTermMemory;
   /** 嵌入服务（预留，未来用于语义搜索） */
@@ -78,11 +78,11 @@ export class MemorySearchTool {
    * 创建检索工具
    */
   constructor(
-    shortTerm: ShortTermMemory,
+    candidatePool: MemoryCandidatePool,
     longTerm: LongTermMemory,
     embeddingService: IEmbeddingService
   ) {
-    this.shortTerm = shortTerm;
+    this.candidatePool = candidatePool;
     this.longTerm = longTerm;
     this.embeddingService = embeddingService;
   }
@@ -100,9 +100,9 @@ export class MemorySearchTool {
     const allResults: SearchResult[] = [];
 
     // 1. 检索短期记忆
-    if (!types || types.includes('short-term')) {
+    if (!types || types.includes('candidate')) {
       let shortEntries = sessionId
-        ? await this.shortTerm.list(sessionId)
+        ? await this.candidatePool.list(sessionId)
         : await this.getAllShortTerm();
 
       for (const entry of shortEntries) {
@@ -141,11 +141,11 @@ export class MemorySearchTool {
    * 获取所有短期记忆
    */
   private async getAllShortTerm(): Promise<MemoryEntry[]> {
-    const stats = this.shortTerm.getStats();
+    const stats = this.candidatePool.getStats();
     const allEntries: MemoryEntry[] = [];
 
     for (const sessionId of Object.keys(stats.bySession)) {
-      const entries = await this.shortTerm.list(sessionId);
+      const entries = await this.candidatePool.list(sessionId);
       allEntries.push(...entries);
     }
 

--- a/src/memory/tools/write.ts
+++ b/src/memory/tools/write.ts
@@ -160,7 +160,7 @@ export class MemoryWriteTool {
       return 'type 参数不能为空';
     }
 
-    const validTypes: MemoryType[] = ['short-term', 'long-term'];
+    const validTypes: MemoryType[] = ['candidate', 'long-term'];
     if (!validTypes.includes(params.type)) {
       return `type 参数无效，必须是 ${validTypes.join(' 或 ')}`;
     }

--- a/tests/integration/dual-layer.test.ts
+++ b/tests/integration/dual-layer.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { ShortTermMemory } from '../../src/memory/store/short-term.js';
+import { MemoryCandidatePool } from '../../src/memory/store/candidate-pool.js';
 import { LongTermMemory } from '../../src/memory/store/long-term.js';
 import { SessionManager } from '../../src/memory/store/session-manager.js';
 import { TTLManager } from '../../src/memory/store/ttl-manager.js';
@@ -20,7 +20,7 @@ import { SensitiveDetector } from '../../src/memory/write/sensitive-detector.js'
 import * as fs from 'fs/promises';
 
 describe('Dual-Layer Memory Integration', () => {
-  let shortTerm: ShortTermMemory;
+  let candidatePool: MemoryCandidatePool;
   let longTerm: LongTermMemory;
   let sessionManager: SessionManager;
   let ttlManager: TTLManager;
@@ -35,22 +35,22 @@ describe('Dual-Layer Memory Integration', () => {
     
     // 初始化所有组件
     sessionManager = new SessionManager();
-    shortTerm = new ShortTermMemory(sessionManager);
+    candidatePool = new MemoryCandidatePool(sessionManager);
     longTerm = new LongTermMemory(testDir);
     embeddingService = new EmbeddingService();
     
     const dedupChecker = new DeduplicationChecker(embeddingService);
     const sensitiveDetector = new SensitiveDetector();
     
-    writeTool = new MemoryWriteTool(shortTerm, dedupChecker, sensitiveDetector);
-    promoter = new MemoryPromoter(shortTerm, longTerm);
-    ttlManager = new TTLManager(shortTerm, promoter);
-    searchTool = new MemorySearchTool(shortTerm, longTerm, embeddingService);
+    writeTool = new MemoryWriteTool(candidatePool, dedupChecker, sensitiveDetector);
+    promoter = new MemoryPromoter(candidatePool, longTerm);
+    ttlManager = new TTLManager(candidatePool, promoter);
+    searchTool = new MemorySearchTool(candidatePool, longTerm, embeddingService);
   });
 
   afterEach(async () => {
     ttlManager.stop();
-    shortTerm.clear();
+    candidatePool.clear();
     longTerm.clear();
     await fs.rm(testDir, { recursive: true, force: true });
   });
@@ -60,7 +60,7 @@ describe('Dual-Layer Memory Integration', () => {
       const sessionId = sessionManager.create();
 
       // 1. 写入短期记忆（高重要性）
-      const shortId = await shortTerm.write('User prefers dark mode', sessionId, {
+      const shortId = await candidatePool.write('User prefers dark mode', sessionId, {
         importance: 0.8
       });
 
@@ -81,7 +81,7 @@ describe('Dual-Layer Memory Integration', () => {
       const sessionId = sessionManager.create();
 
       // 1. 写入并晋升
-      const shortId = await shortTerm.write('Important preference', sessionId, {
+      const shortId = await candidatePool.write('Important preference', sessionId, {
         importance: 0.9
       });
       await promoter.promote(shortId);
@@ -105,7 +105,7 @@ describe('Dual-Layer Memory Integration', () => {
       const sessionId = sessionManager.create();
 
       // 1. 写入短期记忆（低重要性，短 TTL）
-      await shortTerm.write('Temporary context', sessionId, {
+      await candidatePool.write('Temporary context', sessionId, {
         importance: 0.2,
         ttl: 100 // 100ms
       });
@@ -120,7 +120,7 @@ describe('Dual-Layer Memory Integration', () => {
       expect(result.cleaned).toBe(1); // 低重要性，直接清理
 
       // 4. 验证已删除
-      const remaining = await shortTerm.list(sessionId);
+      const remaining = await candidatePool.list(sessionId);
       expect(remaining.length).toBe(0);
     });
 
@@ -128,7 +128,7 @@ describe('Dual-Layer Memory Integration', () => {
       const sessionId = sessionManager.create();
 
       // 1. 写入短期记忆（高重要性，短 TTL）
-      await shortTerm.write('Important decision', sessionId, {
+      await candidatePool.write('Important decision', sessionId, {
         importance: 0.9,
         ttl: 100
       });
@@ -166,8 +166,8 @@ describe('Dual-Layer Memory Integration', () => {
       const session2 = sessionManager.create();
 
       // 1. 不同 Session 写入
-      await shortTerm.write('Session 1 context', session1);
-      await shortTerm.write('Session 2 context', session2);
+      await candidatePool.write('Session 1 context', session1);
+      await candidatePool.write('Session 2 context', session2);
 
       // 2. 按 Session 搜索
       const session1Results = await searchTool.search({
@@ -191,9 +191,9 @@ describe('Dual-Layer Memory Integration', () => {
       const sessionId = sessionManager.create();
 
       // 1. 写入多条记忆
-      await shortTerm.write('Old memory', sessionId);
+      await candidatePool.write('Old memory', sessionId);
       await new Promise(resolve => setTimeout(resolve, 100));
-      await shortTerm.write('New memory', sessionId);
+      await candidatePool.write('New memory', sessionId);
 
       // 2. 搜索
       const results = await searchTool.search({ query: 'memory' });
@@ -209,9 +209,9 @@ describe('Dual-Layer Memory Integration', () => {
       const sessionId = sessionManager.create();
 
       // 1. 写入多条记忆
-      await shortTerm.write('Memory 1', sessionId, { importance: 0.8 });
-      await shortTerm.write('Memory 2', sessionId, { importance: 0.9 });
-      await shortTerm.write('Memory 3', sessionId, { importance: 0.2 });
+      await candidatePool.write('Memory 1', sessionId, { importance: 0.8 });
+      await candidatePool.write('Memory 2', sessionId, { importance: 0.9 });
+      await candidatePool.write('Memory 3', sessionId, { importance: 0.2 });
 
       // 2. 执行晋升
       await promoter.promoteAll();
@@ -220,7 +220,7 @@ describe('Dual-Layer Memory Integration', () => {
       const promotionStats = promoter.getStats();
       expect(promotionStats.promoted).toBe(2);
 
-      const shortStats = shortTerm.getStats();
+      const shortStats = candidatePool.getStats();
       expect(shortStats.total).toBe(1); // 只剩低重要性的
 
       const longStats = longTerm.getStats();

--- a/tests/integration/gateway-memory.test.ts
+++ b/tests/integration/gateway-memory.test.ts
@@ -80,7 +80,7 @@ describe('Gateway with MemoryManager', () => {
 
       // 验证记忆已写入
       const status = memoryManager.getStatus();
-      expect(status.shortTermCount).toBeGreaterThan(0);
+      expect(status.candidatePoolCount).toBeGreaterThan(0);
     });
 
     it('should fallback to SimpleMemoryStorage when no memoryManager', async () => {
@@ -109,7 +109,7 @@ describe('Gateway with MemoryManager', () => {
         write: vi.fn().mockRejectedValue(new Error('Write failed')),
         initialize: vi.fn().mockResolvedValue(undefined),
         destroy: vi.fn(),
-        getStatus: vi.fn().mockReturnValue({ shortTermCount: 0 })
+        getStatus: vi.fn().mockReturnValue({ candidatePoolCount: 0 })
       } as unknown as MemoryManager;
 
       const gatewayWithFailure = new MiniclawGateway(mockConfig, {

--- a/tests/unit/core/gateway/cleanup-persist.test.ts
+++ b/tests/unit/core/gateway/cleanup-persist.test.ts
@@ -43,7 +43,7 @@ const createMockMemoryManager = (): MemoryManager => {
     cleanup: vi.fn(async () => ({ expired: 0, promoted: 0, cleaned: 0 })),
     persist: vi.fn(async () => {}),
     getStatus: vi.fn(() => ({
-      shortTermCount: 0,
+      candidatePoolCount: 0,
       longTermCount: 0,
       bySession: {},
       avgImportance: 0,

--- a/tests/unit/memory/auto-writer.test.ts
+++ b/tests/unit/memory/auto-writer.test.ts
@@ -21,7 +21,7 @@ describe('AutoMemoryWriter', () => {
       persist: vi.fn().mockResolvedValue(undefined),
       initialize: vi.fn().mockResolvedValue(undefined),
       destroy: vi.fn(),
-      getStatus: vi.fn().mockReturnValue({ shortTermCount: 0, longTermCount: 0 })
+      getStatus: vi.fn().mockReturnValue({ candidatePoolCount: 0, longTermCount: 0 })
     } as unknown as MemoryManager;
 
     writer = new AutoMemoryWriter(mockManager);

--- a/tests/unit/memory/manager.test.ts
+++ b/tests/unit/memory/manager.test.ts
@@ -37,7 +37,7 @@ describe('MemoryManager', () => {
 
       const status = manager.getStatus();
       expect(status.ttlRunning).toBe(true);
-      expect(status.shortTermCount).toBe(0);
+      expect(status.candidatePoolCount).toBe(0);
       expect(status.longTermCount).toBe(0);
     });
   });
@@ -50,7 +50,7 @@ describe('MemoryManager', () => {
       expect(id).toBeDefined();
 
       const status = manager.getStatus();
-      expect(status.shortTermCount).toBe(1);
+      expect(status.candidatePoolCount).toBe(1);
     });
 
     it('should write with custom importance', async () => {

--- a/tests/unit/memory/store.test.ts
+++ b/tests/unit/memory/store.test.ts
@@ -25,7 +25,7 @@ describe('MemoryStore', () => {
     });
 
     it('should write with metadata', async () => {
-      const id = await store.write('Test content', 'short-term', {
+      const id = await store.write('Test content', 'candidate', {
         sessionId: 'session-123',
         importance: 0.8,
         tags: ['test']
@@ -95,7 +95,7 @@ describe('MemoryStore', () => {
 
   describe('delete', () => {
     it('should delete existing memory entry', async () => {
-      const id = await store.write('To be deleted', 'short-term');
+      const id = await store.write('To be deleted', 'candidate');
       const success = await store.delete(id);
 
       expect(success).toBe(true);
@@ -112,7 +112,7 @@ describe('MemoryStore', () => {
   describe('list', () => {
     it('should list all memory entries', async () => {
       await store.write('Memory 1', 'long-term');
-      await store.write('Memory 2', 'short-term');
+      await store.write('Memory 2', 'candidate');
       await store.write('Memory 3', 'long-term');
 
       const entries = await store.list();
@@ -121,16 +121,16 @@ describe('MemoryStore', () => {
 
     it('should filter by type', async () => {
       await store.write('Long-term 1', 'long-term');
-      await store.write('Short-term 1', 'short-term');
+      await store.write('Short-term 1', 'candidate');
       await store.write('Long-term 2', 'long-term');
 
       const longTermEntries = await store.list('long-term');
       expect(longTermEntries.length).toBe(2);
       expect(longTermEntries.every(e => e.type === 'long-term')).toBe(true);
 
-      const shortTermEntries = await store.list('short-term');
-      expect(shortTermEntries.length).toBe(1);
-      expect(shortTermEntries.every(e => e.type === 'short-term')).toBe(true);
+      const candidateEntries = await store.list('candidate');
+      expect(candidateEntries.length).toBe(1);
+      expect(candidateEntries.every(e => e.type === 'candidate')).toBe(true);
     });
 
     it('should return empty array when no entries', async () => {
@@ -143,7 +143,7 @@ describe('MemoryStore', () => {
     it('should search by keyword', async () => {
       await store.write('User prefers Python programming', 'long-term');
       await store.write('User likes Rust', 'long-term');
-      await store.write('Weather is nice today', 'short-term');
+      await store.write('Weather is nice today', 'candidate');
 
       const results = await store.search({ query: 'Python' });
       expect(results.length).toBe(1);
@@ -169,7 +169,7 @@ describe('MemoryStore', () => {
 
     it('should filter by type', async () => {
       await store.write('Python long-term', 'long-term');
-      await store.write('Python short-term', 'short-term');
+      await store.write('Python short-term', 'candidate');
 
       const longTermResults = await store.search({
         query: 'Python',

--- a/tests/unit/promotion/promoter.test.ts
+++ b/tests/unit/promotion/promoter.test.ts
@@ -8,14 +8,14 @@
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import { MemoryPromoter } from '../../../src/memory/promotion/promoter.js';
-import { ShortTermMemory } from '../../../src/memory/store/short-term.js';
+import { MemoryCandidatePool } from '../../../src/memory/store/candidate-pool.js';
 import { LongTermMemory } from '../../../src/memory/store/long-term.js';
 import { SessionManager } from '../../../src/memory/store/session-manager.js';
 import * as fs from 'fs/promises';
 
 describe('MemoryPromoter', () => {
   let promoter: MemoryPromoter;
-  let shortTerm: ShortTermMemory;
+  let candidatePool: MemoryCandidatePool;
   let longTerm: LongTermMemory;
   let sessionManager: SessionManager;
   const testDir = '/tmp/miniclaw-promotion-test';
@@ -23,19 +23,19 @@ describe('MemoryPromoter', () => {
   beforeEach(async () => {
     await fs.mkdir(testDir, { recursive: true });
     sessionManager = new SessionManager();
-    shortTerm = new ShortTermMemory(sessionManager);
+    candidatePool = new MemoryCandidatePool(sessionManager);
     longTerm = new LongTermMemory(testDir);
-    promoter = new MemoryPromoter(shortTerm, longTerm);
+    promoter = new MemoryPromoter(candidatePool, longTerm);
   });
 
   describe('check', () => {
     it('should return true for high importance', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Important decision', sessionId, {
+      const id = await candidatePool.write('Important decision', sessionId, {
         importance: 0.9
       });
 
-      const entry = await shortTerm.read(id);
+      const entry = await candidatePool.read(id);
       const shouldPromote = promoter.check(entry!);
 
       expect(shouldPromote).toBe(true);
@@ -43,11 +43,11 @@ describe('MemoryPromoter', () => {
 
     it('should return false for low importance', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Normal context', sessionId, {
+      const id = await candidatePool.write('Normal context', sessionId, {
         importance: 0.3
       });
 
-      const entry = await shortTerm.read(id);
+      const entry = await candidatePool.read(id);
       const shouldPromote = promoter.check(entry!);
 
       expect(shouldPromote).toBe(false);
@@ -57,11 +57,11 @@ describe('MemoryPromoter', () => {
       promoter.setThreshold(0.7);
 
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Medium importance', sessionId, {
+      const id = await candidatePool.write('Medium importance', sessionId, {
         importance: 0.6
       });
 
-      const entry = await shortTerm.read(id);
+      const entry = await candidatePool.read(id);
       const shouldPromote = promoter.check(entry!);
 
       expect(shouldPromote).toBe(false);
@@ -69,11 +69,11 @@ describe('MemoryPromoter', () => {
 
     it('should promote with importance 0.5 by default', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Decision', sessionId, {
+      const id = await candidatePool.write('Decision', sessionId, {
         importance: 0.5
       });
 
-      const entry = await shortTerm.read(id);
+      const entry = await candidatePool.read(id);
       const shouldPromote = promoter.check(entry!);
 
       expect(shouldPromote).toBe(true);
@@ -83,7 +83,7 @@ describe('MemoryPromoter', () => {
   describe('promote', () => {
     it('should promote short-term to long-term', async () => {
       const sessionId = 'session-123';
-      const shortId = await shortTerm.write('Important info', sessionId, {
+      const shortId = await candidatePool.write('Important info', sessionId, {
         importance: 0.8
       });
 
@@ -99,19 +99,19 @@ describe('MemoryPromoter', () => {
 
     it('should delete short-term after promotion', async () => {
       const sessionId = 'session-123';
-      const shortId = await shortTerm.write('To promote', sessionId, {
+      const shortId = await candidatePool.write('To promote', sessionId, {
         importance: 0.9
       });
 
       await promoter.promote(shortId);
 
-      const shortEntry = await shortTerm.read(shortId);
+      const shortEntry = await candidatePool.read(shortId);
       expect(shortEntry).toBeNull();
     });
 
     it('should preserve metadata', async () => {
       const sessionId = 'session-123';
-      const shortId = await shortTerm.write('With metadata', sessionId, {
+      const shortId = await candidatePool.write('With metadata', sessionId, {
         importance: 0.8,
         tags: ['important', 'work']
       });
@@ -130,7 +130,7 @@ describe('MemoryPromoter', () => {
 
     it('should return null if check fails', async () => {
       const sessionId = 'session-123';
-      const shortId = await shortTerm.write('Low importance', sessionId, {
+      const shortId = await candidatePool.write('Low importance', sessionId, {
         importance: 0.1
       });
 
@@ -144,9 +144,9 @@ describe('MemoryPromoter', () => {
     it('should promote all eligible memories', async () => {
       const sessionId = 'session-123';
 
-      await shortTerm.write('High 1', sessionId, { importance: 0.8 });
-      await shortTerm.write('High 2', sessionId, { importance: 0.9 });
-      await shortTerm.write('Low', sessionId, { importance: 0.2 });
+      await candidatePool.write('High 1', sessionId, { importance: 0.8 });
+      await candidatePool.write('High 2', sessionId, { importance: 0.9 });
+      await candidatePool.write('Low', sessionId, { importance: 0.2 });
 
       const promotedIds = await promoter.promoteAll();
 
@@ -161,9 +161,9 @@ describe('MemoryPromoter', () => {
     it('should return promotion statistics', async () => {
       const sessionId = 'session-123';
 
-      await shortTerm.write('Promoted 1', sessionId, { importance: 0.8 });
-      await shortTerm.write('Promoted 2', sessionId, { importance: 0.9 });
-      await shortTerm.write('Low', sessionId, { importance: 0.2 });
+      await candidatePool.write('Promoted 1', sessionId, { importance: 0.8 });
+      await candidatePool.write('Promoted 2', sessionId, { importance: 0.9 });
+      await candidatePool.write('Low', sessionId, { importance: 0.2 });
 
       promoter.resetStats(); // 重置统计
       await promoter.promoteAll();

--- a/tests/unit/store/candidate-pool.test.ts
+++ b/tests/unit/store/candidate-pool.test.ts
@@ -1,51 +1,51 @@
 /**
- * @fileoverview 短期记忆管理测试
+ * @fileoverview 记忆候选池管理测试
  *
- * 测试短期记忆的核心功能。
+ * 测试记忆候选池的核心功能。
  *
- * @module tests/unit/store/short-term.test
+ * @module tests/unit/store/candidate-pool.test
  */
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
-import { ShortTermMemory } from '../../../src/memory/store/short-term.js';
+import { MemoryCandidatePool } from '../../../src/memory/store/candidate-pool.js';
 import { SessionManager } from '../../../src/memory/store/session-manager.js';
 
-describe('ShortTermMemory', () => {
-  let shortTerm: ShortTermMemory;
+describe('MemoryCandidatePool', () => {
+  let candidatePool: MemoryCandidatePool;
   let sessionManager: SessionManager;
 
   beforeEach(() => {
     sessionManager = new SessionManager();
-    shortTerm = new ShortTermMemory(sessionManager);
+    candidatePool = new MemoryCandidatePool(sessionManager);
   });
 
   afterEach(() => {
-    shortTerm.clear();
+    candidatePool.clear();
   });
 
   describe('write', () => {
-    it('should write short-term memory with session id', async () => {
+    it('should write candidate memory with session id', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('User context', sessionId);
+      const id = await candidatePool.write('User context', sessionId);
 
       expect(id).toBeDefined();
-      expect(id).toMatch(/^short-/);
+      expect(id).toMatch(/^candidate-/);
     });
 
     it('should store content with sessionId', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Test content', sessionId);
+      const id = await candidatePool.write('Test content', sessionId);
 
-      const entry = await shortTerm.read(id);
+      const entry = await candidatePool.read(id);
       expect(entry?.metadata.sessionId).toBe(sessionId);
-      expect(entry?.type).toBe('short-term');
+      expect(entry?.type).toBe('candidate');
     });
 
     it('should set TTL metadata', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Test', sessionId);
+      const id = await candidatePool.write('Test', sessionId);
 
-      const entry = await shortTerm.read(id);
+      const entry = await candidatePool.read(id);
       expect(entry?.metadata.ttl).toBeDefined();
       expect(entry?.metadata.ttl).toBeGreaterThan(0);
     });
@@ -54,14 +54,14 @@ describe('ShortTermMemory', () => {
   describe('read', () => {
     it('should read existing memory', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Test content', sessionId);
+      const id = await candidatePool.write('Test content', sessionId);
 
-      const entry = await shortTerm.read(id);
+      const entry = await candidatePool.read(id);
       expect(entry?.content).toBe('Test content');
     });
 
     it('should return null for non-existing id', async () => {
-      const entry = await shortTerm.read('non-existing');
+      const entry = await candidatePool.read('non-existing');
       expect(entry).toBeNull();
     });
   });
@@ -71,19 +71,19 @@ describe('ShortTermMemory', () => {
       const session1 = 'session-1';
       const session2 = 'session-2';
 
-      await shortTerm.write('Memory 1', session1);
-      await shortTerm.write('Memory 2', session1);
-      await shortTerm.write('Memory 3', session2);
+      await candidatePool.write('Memory 1', session1);
+      await candidatePool.write('Memory 2', session1);
+      await candidatePool.write('Memory 3', session2);
 
-      const session1Memories = await shortTerm.list(session1);
+      const session1Memories = await candidatePool.list(session1);
       expect(session1Memories.length).toBe(2);
 
-      const session2Memories = await shortTerm.list(session2);
+      const session2Memories = await candidatePool.list(session2);
       expect(session2Memories.length).toBe(1);
     });
 
     it('should return empty array for unknown session', async () => {
-      const memories = await shortTerm.list('unknown-session');
+      const memories = await candidatePool.list('unknown-session');
       expect(memories).toEqual([]);
     });
   });
@@ -91,32 +91,32 @@ describe('ShortTermMemory', () => {
   describe('delete', () => {
     it('should delete memory', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('To delete', sessionId);
+      const id = await candidatePool.write('To delete', sessionId);
 
-      const success = await shortTerm.delete(id);
+      const success = await candidatePool.delete(id);
       expect(success).toBe(true);
 
-      const entry = await shortTerm.read(id);
+      const entry = await candidatePool.read(id);
       expect(entry).toBeNull();
     });
 
     it('should return false for non-existing id', async () => {
-      const success = await shortTerm.delete('non-existing');
+      const success = await candidatePool.delete('non-existing');
       expect(success).toBe(false);
     });
   });
 
   describe('clear', () => {
     it('should clear all memories', async () => {
-      await shortTerm.write('Memory 1', 'session-1');
-      await shortTerm.write('Memory 2', 'session-2');
+      await candidatePool.write('Memory 1', 'session-1');
+      await candidatePool.write('Memory 2', 'session-2');
 
-      shortTerm.clear();
+      candidatePool.clear();
 
-      const session1Memories = await shortTerm.list('session-1');
+      const session1Memories = await candidatePool.list('session-1');
       expect(session1Memories).toEqual([]);
 
-      const session2Memories = await shortTerm.list('session-2');
+      const session2Memories = await candidatePool.list('session-2');
       expect(session2Memories).toEqual([]);
     });
   });
@@ -124,20 +124,20 @@ describe('ShortTermMemory', () => {
   describe('TTL', () => {
     it('should check expired memories', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Test', sessionId, { ttl: 100 }); // 100ms TTL
+      const id = await candidatePool.write('Test', sessionId, { ttl: 100 }); // 100ms TTL
 
       // 等待过期
       await new Promise(resolve => setTimeout(resolve, 150));
 
-      const isExpired = shortTerm.isExpired(id);
+      const isExpired = candidatePool.isExpired(id);
       expect(isExpired).toBe(true);
     });
 
     it('should not expire fresh memories', async () => {
       const sessionId = 'session-123';
-      const id = await shortTerm.write('Test', sessionId);
+      const id = await candidatePool.write('Test', sessionId);
 
-      const isExpired = shortTerm.isExpired(id);
+      const isExpired = candidatePool.isExpired(id);
       expect(isExpired).toBe(false);
     });
   });

--- a/tests/unit/store/ttl-manager.test.ts
+++ b/tests/unit/store/ttl-manager.test.ts
@@ -8,14 +8,14 @@
 
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { TTLManager } from '../../../src/memory/store/ttl-manager.js';
-import { ShortTermMemory } from '../../../src/memory/store/short-term.js';
+import { MemoryCandidatePool } from '../../../src/memory/store/candidate-pool.js';
 import { SessionManager } from '../../../src/memory/store/session-manager.js';
 import { MemoryPromoter } from '../../../src/memory/promotion/promoter.js';
 import { LongTermMemory } from '../../../src/memory/store/long-term.js';
 
 describe('TTLManager', () => {
   let ttlManager: TTLManager;
-  let shortTerm: ShortTermMemory;
+  let candidatePool: MemoryCandidatePool;
   let sessionManager: SessionManager;
   let promoter: MemoryPromoter;
   let longTerm: LongTermMemory;
@@ -23,15 +23,15 @@ describe('TTLManager', () => {
 
   beforeEach(() => {
     sessionManager = new SessionManager();
-    shortTerm = new ShortTermMemory(sessionManager);
+    candidatePool = new MemoryCandidatePool(sessionManager);
     longTerm = new LongTermMemory(testDir);
-    promoter = new MemoryPromoter(shortTerm, longTerm);
-    ttlManager = new TTLManager(shortTerm, promoter);
+    promoter = new MemoryPromoter(candidatePool, longTerm);
+    ttlManager = new TTLManager(candidatePool, promoter);
   });
 
   afterEach(() => {
     ttlManager.stop();
-    shortTerm.clear();
+    candidatePool.clear();
   });
 
   describe('cleanup', () => {
@@ -39,7 +39,7 @@ describe('TTLManager', () => {
       const sessionId = 'session-123';
 
       // 写入一个短期记忆，TTL 100ms
-      await shortTerm.write('Expired', sessionId, { ttl: 100 });
+      await candidatePool.write('Expired', sessionId, { ttl: 100 });
 
       // 等待过期
       await new Promise(resolve => setTimeout(resolve, 150));
@@ -53,7 +53,7 @@ describe('TTLManager', () => {
     it('should not cleanup fresh memories', async () => {
       const sessionId = 'session-123';
 
-      await shortTerm.write('Fresh', sessionId);
+      await candidatePool.write('Fresh', sessionId);
 
       const cleaned = await ttlManager.cleanup();
 
@@ -64,7 +64,7 @@ describe('TTLManager', () => {
       const sessionId = 'session-123';
 
       // 写入一个重要但即将过期的记忆
-      await shortTerm.write('Important', sessionId, {
+      await candidatePool.write('Important', sessionId, {
         ttl: 100,
         importance: 0.8
       });
@@ -99,7 +99,7 @@ describe('TTLManager', () => {
 
     it('should run cleanup on schedule', async () => {
       const sessionId = 'session-123';
-      await shortTerm.write('Expired', sessionId, { ttl: 100 });
+      await candidatePool.write('Expired', sessionId, { ttl: 100 });
 
       // 启动定时清理（每 200ms）
       ttlManager.schedule(200);
@@ -117,8 +117,8 @@ describe('TTLManager', () => {
     it('should return cleanup statistics', async () => {
       const sessionId = 'session-123';
 
-      await shortTerm.write('Expired 1', sessionId, { ttl: 100 });
-      await shortTerm.write('Expired 2', sessionId, { ttl: 100 });
+      await candidatePool.write('Expired 1', sessionId, { ttl: 100 });
+      await candidatePool.write('Expired 2', sessionId, { ttl: 100 });
 
       await new Promise(resolve => setTimeout(resolve, 150));
 

--- a/tests/unit/tools/search.test.ts
+++ b/tests/unit/tools/search.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { MemorySearchTool } from '../../../src/memory/tools/search.js';
-import { ShortTermMemory } from '../../../src/memory/store/short-term.js';
+import { MemoryCandidatePool } from '../../../src/memory/store/candidate-pool.js';
 import { LongTermMemory } from '../../../src/memory/store/long-term.js';
 import { SessionManager } from '../../../src/memory/store/session-manager.js';
 import { EmbeddingService } from '../../../src/memory/embedding/index.js';
@@ -16,7 +16,7 @@ import * as fs from 'fs/promises';
 
 describe('MemorySearchTool', () => {
   let searchTool: MemorySearchTool;
-  let shortTerm: ShortTermMemory;
+  let candidatePool: MemoryCandidatePool;
   let longTerm: LongTermMemory;
   let sessionManager: SessionManager;
   let embeddingService: EmbeddingService;
@@ -25,14 +25,14 @@ describe('MemorySearchTool', () => {
   beforeEach(async () => {
     await fs.mkdir(testDir, { recursive: true });
     sessionManager = new SessionManager();
-    shortTerm = new ShortTermMemory(sessionManager);
+    candidatePool = new MemoryCandidatePool(sessionManager);
     longTerm = new LongTermMemory(testDir);
     embeddingService = new EmbeddingService();
-    searchTool = new MemorySearchTool(shortTerm, longTerm, embeddingService);
+    searchTool = new MemorySearchTool(candidatePool, longTerm, embeddingService);
   });
 
   afterEach(async () => {
-    shortTerm.clear();
+    candidatePool.clear();
     await fs.rm(testDir, { recursive: true, force: true });
   });
 
@@ -40,7 +40,7 @@ describe('MemorySearchTool', () => {
     it('should search both layers by default', async () => {
       const sessionId = 'session-123';
 
-      await shortTerm.write('Short-term context', sessionId);
+      await candidatePool.write('Short-term context', sessionId);
       await longTerm.write('Long-term context');
 
       const results = await searchTool.search({ query: 'context' });
@@ -52,17 +52,17 @@ describe('MemorySearchTool', () => {
     it('should filter by type', async () => {
       const sessionId = 'session-123';
 
-      await shortTerm.write('Short-term context', sessionId);
+      await candidatePool.write('Short-term context', sessionId);
       await longTerm.write('Long-term context');
 
       // 仅搜索短期记忆
       const shortResults = await searchTool.search({
         query: 'context',
-        types: ['short-term']
+        types: ['candidate']
       });
 
       expect(shortResults.length).toBe(1);
-      expect(shortResults[0].entry.type).toBe('short-term');
+      expect(shortResults[0].entry.type).toBe('candidate');
 
       // 仅搜索长期记忆
       const longResults = await searchTool.search({
@@ -77,9 +77,9 @@ describe('MemorySearchTool', () => {
     it('should limit results', async () => {
       const sessionId = 'session-123';
 
-      await shortTerm.write('Memory 1', sessionId);
-      await shortTerm.write('Memory 2', sessionId);
-      await shortTerm.write('Memory 3', sessionId);
+      await candidatePool.write('Memory 1', sessionId);
+      await candidatePool.write('Memory 2', sessionId);
+      await candidatePool.write('Memory 3', sessionId);
 
       const results = await searchTool.search({ query: 'Memory', limit: 2 });
 
@@ -90,8 +90,8 @@ describe('MemorySearchTool', () => {
       const session1 = 'session-1';
       const session2 = 'session-2';
 
-      await shortTerm.write('Session 1 context', session1);
-      await shortTerm.write('Session 2 context', session2);
+      await candidatePool.write('Session 1 context', session1);
+      await candidatePool.write('Session 2 context', session2);
 
       const results = await searchTool.search({
         query: 'context',
@@ -104,7 +104,7 @@ describe('MemorySearchTool', () => {
 
     it('should return empty array for no matches', async () => {
       const sessionId = 'session-123';
-      await shortTerm.write('Some content', sessionId);
+      await candidatePool.write('Some content', sessionId);
 
       const results = await searchTool.search({ query: 'nonexistent' });
 
@@ -142,7 +142,7 @@ describe('MemorySearchTool', () => {
     it('should return search statistics', async () => {
       const sessionId = 'session-123';
 
-      await shortTerm.write('Test', sessionId);
+      await candidatePool.write('Test', sessionId);
       await longTerm.write('Test');
 
       await searchTool.search({ query: 'Test' });

--- a/tests/unit/tools/write.test.ts
+++ b/tests/unit/tools/write.test.ts
@@ -66,7 +66,7 @@ describe('MemoryWriteTool', () => {
     it('should write with metadata', async () => {
       const result = await tool.execute({
         content: 'Test content',
-        type: 'short-term',
+        type: 'candidate',
         metadata: {
           sessionId: 'session-123',
           importance: 0.8,


### PR DESCRIPTION
- Rename ShortTermMemory class to MemoryCandidatePool
- Rename short-term.ts to candidate-pool.ts
- Update all references (74 places)
- Update MemoryType: 'short-term' -> 'candidate'
- Update variable names: shortTerm -> candidatePool
- Update test descriptions and assertions
- All 800 tests passed

This clarifies the actual purpose: candidate pool for promotion, not short-term memory storage (session.json is the real short-term memory).