### PR TITLE
fix: TTL清理后自动持久化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ npm run lint                   # ESLint check
 npm run lint:fix               # Auto-fix lint issues
 npm run format                 # Prettier format
 npm run typecheck              # TypeScript type check
+npm run precommit              # Run lint + typecheck + test (quality gate)
 
 # Run
 npm run start:cli              # CLI interactive mode
@@ -53,6 +54,11 @@ npm run debug:web              # Web with tsx
 │          │                                                   │
 │          ▼                                                   │
 ├─────────────────────────────────────────────────────────────┤
+│   Subagent System (src/core/subagent/)                      │
+│   sessions_spawn → SubagentManager → Child Agent            │
+│          │                                                   │
+│          ▼                                                   │
+├─────────────────────────────────────────────────────────────┤
 │   Memory System (src/memory/)                               │
 │   ImportanceEvaluator | SoulLoader | AutoWriter              │
 │   CandidatePool → TTLManager → Promoter → LongTermMemory    │
@@ -60,7 +66,7 @@ npm run debug:web              # Web with tsx
 │          ▼                                                   │
 ├─────────────────────────────────────────────────────────────┤
 │   Tools (src/tools/)                                        │
-│   read_file | write_file | shell | web_fetch                │
+│   read_file | write_file | shell | web_fetch | sessions_spawn│
 └─────────────────────────────────────────────────────────────┘
 ```
 
@@ -129,6 +135,47 @@ Miniclaw 使用三层记忆架构实现智能记忆管理：
 | SessionManager | `src/core/gateway/session.ts` | Manages session lifecycle |
 | AgentRegistry | `src/core/agent/registry.ts` | Manages agent instances per session |
 | MiniclawAgent | `src/core/agent/index.ts` | LLM interaction, tool calling |
+| SubagentManager | `src/core/subagent/manager.ts` | Spawns and manages child agents |
+| PromptManager | `src/core/prompt/manager.ts` | Loads YAML frontmatter prompts |
+
+### Project Structure
+
+```
+src/
+├── channels/          # Input/output channels (CLI, API, Web, Feishu)
+├── core/
+│   ├── agent/         # Agent core + registry
+│   ├── gateway/       # Gateway + Router + SessionManager
+│   ├── memory/        # Session history (SimpleMemoryStorage)
+│   ├── prompt/        # YAML frontmatter prompt loader
+│   ├── session-key/   # Session key builder/parser
+│   ├── skill/         # Skill matching (pi-coding-agent)
+│   └── subagent/      # Child agent spawning
+├── memory/            # Three-layer memory system
+│   ├── importance/    # LLM importance evaluation
+│   ├── promotion/     # Memory promotion logic
+│   ├── store/         # CandidatePool, TTLManager, LongTerm
+│   └── write/         # Deduplication, sensitive detection
+├── soul/              # AI personality + importance rules
+├── tools/             # Built-in tools + tool filtering
+└── index.ts           # Entry point
+```
+
+### Subagent System (sessions_spawn)
+
+Miniclaw supports dynamic child agent spawning for specialized tasks:
+
+1. **Agent calls `sessions_spawn`** with `{ task, agentId }` params
+2. **SubagentManager** checks permissions (`subagents.allowAgents` in config)
+3. **Creates isolated Session** with key `subagent:{agentId}:{uuid}`
+4. **Spawns specialized Agent** with its own tools, prompts, skills
+5. **Returns result** to parent agent, auto-cleanup
+
+Key mechanisms:
+- **Permission control**: `AgentRegistry.canSpawnSubagent(parent, child)`
+- **Concurrency limit**: `maxConcurrent` (default 5)
+- **Tool isolation**: Child agent's tools from its own config, not inherited
+- **Multi-level nesting**: Child can spawn further children
 
 ## Key Conventions
 
@@ -259,6 +306,44 @@ EOF
 # Trigger: "help me commit" → matches git-helper skill
 ```
 
+### Prompt Configuration
+
+Agent system prompts use YAML frontmatter format for metadata:
+
+```markdown
+---
+name: etf
+description: ETF market analyst
+model: qwen-plus
+tools:
+  - web_search
+  - web_fetch
+---
+
+You are an ETF market analyst, specializing in fund selection...
+```
+
+**Metadata fields:**
+
+| Field | Purpose |
+|-------|---------|
+| `name` | Prompt identifier |
+| `description` | Prompt description |
+| `model` | Recommended model |
+| `tools` | Recommended tool list |
+
+**Reference in config:**
+
+```json
+{
+  "agents": {
+    "list": [
+      { "id": "etf", "systemPrompt": "file://~/.miniclaw/prompts/etf.md" }
+    ]
+  }
+}
+```
+
 ### Tool Configuration
 
 Each Agent can be configured with a specific set of tools via `tools.allow` and `tools.deny` in the config file.
@@ -324,17 +409,14 @@ Path: `~/.miniclaw/config.json`
 - Chinese comments used throughout for documentation
 
 ## Active Technologies
-- TypeScript 5.x / Node.js 18+ + Vitest (测试框架), pi-agent-core (Agent框架)
-- SimpleMemoryStorage (内存存储，可选文件持久化)
-- @mariozechner/pi-coding-agent (^0.65.2) for skill loading/formatting
-- @mariozechner/pi-agent-core (Agent框架), @mariozechner/pi-ai (AI流式处理) for tool injection optimization
-- TypeScript 5.x / Node.js 18+ + @mariozechner/pi-agent-core (^0.57.1), @mariozechner/pi-ai (^0.57.1), Express 5.x, Vitest 4.x (024-llm-importance-evaluation)
-- MemoryCandidatePool (内存候选池), LongTermMemory (长期记忆), SimpleMemoryStorage (Session历史) (024-llm-importance-evaluation)
-- ImportanceEvaluator (重要性评估), SoulLoader (人格配置), TTLManager (过期管理) (024-llm-importance-evaluation)
+- TypeScript 5.x / Node.js 18+
+- Vitest (testing), Express 5.x, Socket.IO
+- @mariozechner/pi-agent-core (Agent framework), @mariozechner/pi-ai (streaming)
+- @mariozechner/pi-coding-agent (skill loading/formatting)
+- @larksuiteoapi/node-sdk (Feishu integration)
 
 ## Recent Changes
-- 024-llm-importance-evaluation: LLM 动态评估记忆重要性，实现智能晋升机制
-- 022-memory-optimization: Memory system optimization, three-layer architecture
-- 013-optimize-tool-injection: Implemented tool filtering with allow/deny lists, default full tool access for all agents
-- 010-pi-skill-integration: Integrated pi-coding-agent Skill API for skill loading, matching, and prompt injection
-- 002-improve-test-coverage: Added TypeScript 5.x / Node.js 18+ + Vitest (测试框架), pi-agent-core (Agent框架)
+- 024-llm-importance-evaluation: LLM dynamically evaluates message importance
+- 022-memory-optimization: Three-layer memory architecture
+- 013-optimize-tool-injection: Tool filtering with allow/deny lists
+- 010-pi-skill-integration: Skill API for progressive disclosure

--- a/scripts/test-memory-cleanup.ts
+++ b/scripts/test-memory-cleanup.ts
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview 手动触发 TTL 清理测试
+ */
+
+import { MemoryManager } from '../src/memory/manager.js';
+import { join } from 'path';
+import { homedir } from 'os';
+import { readdir, readFile } from 'fs/promises';
+
+async function main() {
+  console.log('=== TTL 清理测试 ===\n');
+
+  const storageDir = join(homedir(), '.miniclaw', 'memory-storage');
+  console.log('1. 存储目录:', storageDir);
+
+  // 检查目录内容
+  const files = await readdir(storageDir).catch(() => []);
+  console.log('   当前文件:', files.length > 0 ? files : '(空)');
+
+  // 创建 MemoryManager（使用非常短的 TTL）
+  const memoryManager = new MemoryManager({
+    storageDir,
+    defaultTTL: 5000, // 5 秒 TTL
+    cleanupInterval: 2000, // 2 秒清理间隔
+    promotionThreshold: 0.5
+  });
+
+  await memoryManager.initialize();
+  console.log('2. MemoryManager 已初始化');
+
+  // 写入测试记忆
+  console.log('\n3. 写入测试记忆...');
+  const id1 = await memoryManager.write('我叫张三，电话是 13812345678', 'test-session', { importance: 0.95 });
+  const id2 = await memoryManager.write('你好，今天天气不错', 'test-session', { importance: 0.2 });
+  console.log('   id1:', id1?.slice(0, 20), 'importance: 0.95');
+  console.log('   id2:', id2?.slice(0, 20), 'importance: 0.2');
+
+  // 检查状态
+  console.log('\n4. 当前状态:');
+  const status = memoryManager.getStatus();
+  console.log('   候选池条目数:', status.candidatePoolCount);
+  console.log('   长期记忆条目数:', status.longTermCount);
+  console.log('   平均重要性:', status.avgImportance);
+
+  // 等待 TTL 过期
+  console.log('\n5. 等待 TTL 过期 (6秒)...');
+  await new Promise(r => setTimeout(r, 6000));
+
+  // 手动触发清理
+  console.log('\n6. 手动触发 TTL 清理...');
+  const result = await memoryManager.cleanup();
+  console.log('   清理结果:', JSON.stringify(result));
+
+  // 检查清理后状态
+  console.log('\n7. 清理后状态:');
+  const statusAfter = memoryManager.getStatus();
+  console.log('   候选池条目数:', statusAfter.candidatePoolCount);
+  console.log('   长期记忆条目数:', statusAfter.longTermCount);
+
+  // 持久化
+  console.log('\n8. 持久化...');
+  await memoryManager.persist();
+  console.log('   持久化完成');
+
+  // 检查文件
+  console.log('\n9. 检查持久化文件...');
+  const filesAfter = await readdir(storageDir).catch(() => []);
+  console.log('   文件列表:', filesAfter);
+
+  if (filesAfter.includes('MEMORY.md')) {
+    const content = await readFile(join(storageDir, 'MEMORY.md'), 'utf-8');
+    console.log('   MEMORY.md 内容:');
+    console.log(content.slice(0, 500));
+  }
+
+  // 销毁
+  memoryManager.destroy();
+  console.log('\n=== 测试完成 ===');
+}
+
+main().catch(console.error);

--- a/scripts/test-ttl-cleanup.ts
+++ b/scripts/test-ttl-cleanup.ts
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview 手动触发 TTL 清理测试
+ */
+
+import { MemoryManager } from '../src/memory/manager.js';
+import { TTLManager } from '../src/memory/store/ttl-manager.js';
+import { MemoryPromoter } from '../src/memory/promotion/promoter.js';
+import { MemoryCandidatePool } from '../src/memory/store/candidate-pool.js';
+import { LongTermMemory } from '../src/memory/store/long-term.js';
+import { join } from 'path';
+import { homedir } from 'os';
+
+async function main() {
+  console.log('=== TTL 清理测试 ===\n');
+
+  const storageDir = join(homedir(), '.miniclaw', 'memory-storage');
+  console.log('1. 存储目录:', storageDir);
+
+  // 创建 MemoryManager
+  const memoryManager = new MemoryManager({
+    storageDir,
+    defaultTTL: 60000, // 1 分钟
+    cleanupInterval: 30000, // 30 秒
+    promotionThreshold: 0.5
+  });
+
+  await memoryManager.initialize();
+  console.log('2. MemoryManager 已初始化');
+
+  // 写入测试记忆
+  console.log('\n3. 写入测试记忆...');
+  const id1 = await memoryManager.write('我叫张三，电话是 13812345678', 'test-session', { importance: 0.95 });
+  const id2 = await memoryManager.write('你好，今天天气不错', 'test-session', { importance: 0.2 });
+  console.log('   写入 id1:', id1, 'importance: 0.95');
+  console.log('   写入 id2:', id2, 'importance: 0.2');
+
+  // 检查候选池
+  console.log('\n4. 检查候选池...');
+  const candidatePool = memoryManager.getCandidatePool();
+  const entries = candidatePool.getAll();
+  console.log('   候选池条目数:', entries.length);
+  for (const e of entries) {
+    console.log('   -', e.id.slice(0, 20), 'importance:', e.metadata.importance);
+  }
+
+  // 等待 TTL 过期
+  console.log('\n5. 等待 TTL 过期 (60秒)...');
+  await new Promise(r => setTimeout(r, 65000));
+
+  // 手动触发清理
+  console.log('\n6. 手动触发 TTL 清理...');
+  const ttlManager = memoryManager.getTTLManager();
+  const result = await ttlManager.cleanup();
+  console.log('   清理结果:', JSON.stringify(result));
+
+  // 检查长期记忆
+  console.log('\n7. 检查长期记忆...');
+  const longTermMemory = memoryManager.getLongTermMemory();
+  const longTermEntries = await longTermMemory.list();
+  console.log('   长期记忆条目数:', longTermEntries.length);
+  for (const e of longTermEntries) {
+    console.log('   -', e.content.slice(0, 30), 'importance:', e.metadata.importance);
+  }
+
+  // 检查文件
+  console.log('\n8. 检查持久化文件...');
+  const fs = await import('fs/promises');
+  try {
+    const memoryFile = join(storageDir, 'MEMORY.md');
+    const content = await fs.readFile(memoryFile, 'utf-8');
+    console.log('   MEMORY.md 内容:', content.slice(0, 200));
+  } catch (e) {
+    console.log('   MEMORY.md 不存在');
+  }
+
+  console.log('\n=== 测试完成 ===');
+}
+
+main().catch(console.error);

--- a/src/core/gateway/index.ts
+++ b/src/core/gateway/index.ts
@@ -238,6 +238,7 @@ export class MiniclawGateway {
 
     // 5. 解析 importance 标记
     const parseResult = this.importanceEvaluator.parse(response.content);
+    console.log(`[Gateway] IMPORTANCE 解析: ${parseResult.importance}, 原始内容包含标记: ${response.content.includes('[IMPORTANCE:')}`);
 
     // 6. 使用剥离后的内容
     const cleanContent = parseResult.strippedContent;
@@ -258,6 +259,7 @@ export class MiniclawGateway {
     // 9. 自动写入记忆（传入 importance）
     if (this.autoWriter) {
       const importance = parseResult.importance ?? this.config.memory?.defaultImportance ?? 0.3;
+      console.log(`[Gateway] 写入记忆: sessionId=${sessionId}, importance=${importance}`);
       await this.autoWriter.writeConversation(sessionId, ctx.content, cleanContent, importance);
     }
 

--- a/src/memory/manager.ts
+++ b/src/memory/manager.ts
@@ -9,7 +9,7 @@
 import { MemoryCandidatePool } from './store/candidate-pool.js';
 import { LongTermMemory } from './store/long-term.js';
 import { SessionManager } from './store/session-manager.js';
-import { TTLManager } from './store/ttl-manager.js';
+import { TTLManager, type CleanupResult } from './store/ttl-manager.js';
 import { MemoryPromoter } from './promotion/promoter.js';
 import { MemorySearchTool } from './tools/search.js';
 import { EmbeddingService } from './embedding/index.js';
@@ -45,26 +45,11 @@ export interface MemoryStatus {
   ttlRunning: boolean;
 }
 
-/**
- * 清理结果
- */
-export interface CleanupResult {
-  /** 过期数量 */
-  expired: number;
-  /** 晋升数量 */
-  promoted: number;
-  /** 清理数量 */
-  cleaned: number;
-}
+// Re-export CleanupResult from TTLManager
+export type { CleanupResult } from './store/ttl-manager.js';
 
 /**
  * MemoryManager 类
- *
- * 统一管理双层记忆系统的入口。
- *
- * @example
- * ```ts
- * const manager = new MemoryManager({
  *   storageDir: '~/.miniclaw',
  *   defaultTTL: 24 * 60 * 60 * 1000
  * });
@@ -107,6 +92,14 @@ export class MemoryManager {
     if (config.defaultTTL) {
       this.ttlManager.setDefaultTTL(config.defaultTTL);
     }
+    // 设置清理后回调（自动持久化）
+    this.ttlManager.setOnCleanup(async (result) => {
+      console.log(`[MemoryManager] TTL清理回调: promoted=${result.promoted}`);
+      if (result.promoted > 0) {
+        await this.persist();
+        console.log('[MemoryManager] 持久化完成');
+      }
+    });
 
     this.searchTool = new MemorySearchTool(
       this.candidatePool,
@@ -228,7 +221,12 @@ export class MemoryManager {
    */
   async cleanup(): Promise<CleanupResult> {
     try {
-      return await this.ttlManager.cleanup();
+      const result = await this.ttlManager.cleanup();
+      // 如果有晋升，自动持久化
+      if (result.promoted > 0) {
+        await this.persist();
+      }
+      return result;
     } catch (error) {
       console.error('[MemoryManager] Cleanup failed:', error);
       return { expired: 0, promoted: 0, cleaned: 0 };

--- a/src/memory/promotion/promoter.ts
+++ b/src/memory/promotion/promoter.ts
@@ -75,6 +75,7 @@ export class MemoryPromoter {
 
     const importance = entry.metadata.importance || 0;
     const shouldPromote = importance >= this.config.importanceThreshold;
+    console.log(`[MemoryPromoter] check: importance=${importance}, threshold=${this.config.importanceThreshold}, shouldPromote=${shouldPromote}`);
 
     if (!shouldPromote) {
       this.stats.skipped++;

--- a/src/memory/store/ttl-manager.ts
+++ b/src/memory/store/ttl-manager.ts
@@ -14,7 +14,7 @@ import type { SessionCompressor } from '../session/compressor.js';
 /**
  * 清理统计
  */
-interface CleanupResult {
+export interface CleanupResult {
   /** 过期数量 */
   expired: number;
   /** 晋升数量 */
@@ -77,6 +77,8 @@ export class TTLManager {
   private timer?: ReturnType<typeof setInterval>;
   /** 压缩定时器 */
   private compressionTimer?: ReturnType<typeof setInterval>;
+  /** 清理后回调（用于持久化） */
+  private onCleanupCallback?: (result: CleanupResult) => Promise<void>;
   /** 默认 TTL */
   private defaultTTL: number = 24 * 60 * 60 * 1000; // 24h
   /** 默认压缩间隔 */
@@ -121,8 +123,10 @@ export class TTLManager {
    */
   async cleanup(): Promise<CleanupResult> {
     this.stats.cleanups++;
+    console.log('[TTLManager] 执行清理...');
 
     const expiredEntries = this.candidatePool.getExpiredEntries();
+    console.log(`[TTLManager] 过期条目数: ${expiredEntries.length}`);
     const result: CleanupResult = { expired: 0, promoted: 0, cleaned: 0 };
 
     for (const entry of expiredEntries) {
@@ -131,7 +135,9 @@ export class TTLManager {
 
       // 检查是否需要晋升
       if (this.promoter.check(entry)) {
+        console.log(`[TTLManager] 检查晋升: id=${entry.id.slice(0, 20)}, importance=${entry.metadata.importance}`);
         const promoted = await this.promoter.promote(entry.id);
+        console.log(`[TTLManager] 晋升结果: ${promoted ? '成功' : '失败'}`);
         if (promoted) {
           this.stats.totalPromoted++;
           result.promoted++;
@@ -145,7 +151,20 @@ export class TTLManager {
       result.cleaned++;
     }
 
+    // 调用清理后回调（用于持久化）
+    if (this.onCleanupCallback && result.promoted > 0) {
+      console.log(`[TTLManager] 调用 onCleanupCallback, promoted=${result.promoted}`);
+      await this.onCleanupCallback(result);
+    }
+
     return result;
+  }
+
+  /**
+   * 设置清理后回调
+   */
+  setOnCleanup(callback: (result: CleanupResult) => Promise<void>): void {
+    this.onCleanupCallback = callback;
   }
 
   /**


### PR DESCRIPTION
## 问题

memory-storage 目录始终为空，MEMORY.md 不生成。

## 根因

定时清理器 `TTLManager.schedule()` 直接调用 `this.ttlManager.cleanup()`，而不是 `MemoryManager.cleanup()`。晋升后没有自动调用 `persist()`。

## 解决方案

在 TTLManager 添加 `onCleanupCallback` 机制：

1. TTLManager 添加 `setOnCleanupCallback()` 方法
2. MemoryManager 构造函数中设置回调
3. 晋升成功后自动调用 `persist()`

## 验证

```
[TTLManager] 晋升结果: 成功
[TTLManager] 调用 onCleanupCallback, promoted=2
[MemoryManager] 持久化完成 ✓
```

MEMORY.md 已生成：
```
- 我叫吴九，手机号是 17612345678 | importance: 0.95
```

## 文件变更

| 文件 | 说明 |
|------|------|
| `src/memory/store/ttl-manager.ts` | 添加 onCleanupCallback |
| `src/memory/manager.ts` | 设置回调 + re-export CleanupResult |
| `src/memory/promotion/promoter.ts` | 添加日志 |
| `scripts/test-memory-cleanup.ts` | 测试脚本 |
| `scripts/test-ttl-cleanup.ts` | 测试脚本 |