### PR TITLE
fix: pm2-start.sh 清除代理环境变量，修复飞书 WebSocket 400

### DIFF
--- a/config/pm2-start.sh
+++ b/config/pm2-start.sh
@@ -2,6 +2,9 @@
 # PM2 启动脚本 for miniclaw
 # 首次运行需要: pm2 install pm2-logrotate
 
+# 清除代理环境变量，防止飞书 API 请求走代理导致 400
+unset http_proxy HTTP_PROXY https_proxy HTTPS_PROXY all_proxy ALL_PROXY
+
 echo "启动 miniclaw..."
 pm2 start config/ecosystem.config.cjs
 


### PR DESCRIPTION
## Summary
- 修复 ClashX Pro 代理导致飞书 WebSocket 连接 400 失败问题
- 在 pm2-start.sh 启动前 unset 所有代理环境变量
- 确保飞书 API 请求直连，不经过代理

## Root Cause
- 服务器 ClashX Pro 设置了 http_proxy/https_proxy/all_proxy
- PM2 进程继承代理变量，飞书 SDK 的 axios 请求走了代理
- 代理节点对飞书域名返回 400，WebSocket 无法建立连接

## Test
- 重启 PM2 后验证 WebSocket 正常连接
- 飞书消息收发正常