### PR TITLE
fix: 添加 Windows Git Bash 路径兼容，修复 issue #58

### DIFF
--- a/src/tools/edit.ts
+++ b/src/tools/edit.ts
@@ -4,6 +4,7 @@
  */
 import { readFileSync, writeFileSync } from 'fs';
 import { Type, type Static } from '@sinclair/typebox';
+import { normalizePath } from '../utils/path.js';
 
 /**
  * 工具参数 schema
@@ -42,7 +43,9 @@ export const editTool = {
     params: EditParams,
     _signal?: AbortSignal
   ): Promise<{ content: Array<{ type: 'text'; text: string }>; details: EditDetails }> {
-    const { path, old_string, new_string, replace_all = false } = params;
+    const { old_string, new_string, replace_all = false } = params;
+    const rawPath = params.path;
+    const path = normalizePath(rawPath);
 
     try {
       // 读取文件内容
@@ -52,7 +55,7 @@ export const editTool = {
       if (!content.includes(old_string)) {
         return {
           content: [{ type: 'text', text: `未找到要替换的文本: ${old_string.substring(0, 100)}...` }],
-          details: { path, replacements: 0 }
+          details: { path: rawPath, replacements: 0 }
         };
       }
 
@@ -65,7 +68,7 @@ export const editTool = {
               type: 'text',
               text: `找到 ${matches} 处匹配，old_string 必须唯一匹配。请使用更具体的文本，或使用 replace_all=true。`
             }],
-            details: { path, replacements: 0 }
+            details: { path: rawPath, replacements: 0 }
           };
         }
       }
@@ -93,13 +96,13 @@ export const editTool = {
           type: 'text',
           text: `已替换 ${replacementCount} 处匹配:\n旧文本: ${old_string.substring(0, 100)}${old_string.length > 100 ? '...' : ''}\n新文本: ${new_string.substring(0, 100)}${new_string.length > 100 ? '...' : ''}`
         }],
-        details: { path, replacements: replacementCount }
+        details: { path: rawPath, replacements: replacementCount }
       };
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       return {
         content: [{ type: 'text', text: `文件编辑失败: ${errorMsg}` }],
-        details: { path, replacements: 0 }
+        details: { path: rawPath, replacements: 0 }
       };
     }
   }

--- a/src/tools/glob.ts
+++ b/src/tools/glob.ts
@@ -5,6 +5,7 @@
 import fg from 'fast-glob';
 import { statSync } from 'fs';
 import { Type, type Static } from '@sinclair/typebox';
+import { normalizePath } from '../utils/path.js';
 
 /**
  * 工具参数 schema
@@ -42,7 +43,8 @@ export const globTool = {
     params: GlobParams,
     _signal?: AbortSignal
   ): Promise<{ content: Array<{ type: 'text'; text: string }>; details: GlobDetails }> {
-    const { pattern, path } = params;
+    const { pattern, path: rawPath } = params;
+    const path = rawPath ? normalizePath(rawPath) : undefined;
 
     try {
       // 执行 glob 搜索

--- a/src/tools/grep.ts
+++ b/src/tools/grep.ts
@@ -4,6 +4,7 @@
  */
 import { execSync } from 'child_process';
 import { Type, type Static } from '@sinclair/typebox';
+import { normalizePath } from '../utils/path.js';
 
 /**
  * 工具参数 schema
@@ -83,7 +84,8 @@ export const grepTool = {
       if (glob) args.push('-g', glob);
 
       // 搜索路径
-      const searchPath = path || process.cwd();
+      const rawPath = path || process.cwd();
+      const searchPath = path ? normalizePath(rawPath) : rawPath;
 
       // 构建命令
       const command = `rg ${args.join(' ')} "${pattern.replace(/"/g, '\\"')}" "${searchPath}"`;

--- a/src/tools/ls.ts
+++ b/src/tools/ls.ts
@@ -5,6 +5,7 @@
 import { readdirSync, statSync } from 'fs';
 import { join } from 'path';
 import { Type, type Static } from '@sinclair/typebox';
+import { normalizePath } from '../utils/path.js';
 
 /**
  * 工具参数 schema
@@ -76,7 +77,8 @@ export const lsTool = {
     params: LSParams,
     _signal?: AbortSignal
   ): Promise<{ content: Array<{ type: 'text'; text: string }>; details: LSDetails }> {
-    const { path, ignore = ['node_modules', '.git', 'dist'] } = params;
+    const { path: rawPath, ignore = ['node_modules', '.git', 'dist'] } = params;
+    const path = normalizePath(rawPath);
 
     try {
       // 读取目录内容

--- a/src/tools/multi-edit.ts
+++ b/src/tools/multi-edit.ts
@@ -4,6 +4,7 @@
  */
 import { readFileSync, writeFileSync } from 'fs';
 import { Type, type Static } from '@sinclair/typebox';
+import { normalizePath } from '../utils/path.js';
 
 /**
  * 单个编辑操作
@@ -50,12 +51,14 @@ export const multiEditTool = {
     params: MultiEditParams,
     _signal?: AbortSignal
   ): Promise<{ content: Array<{ type: 'text'; text: string }>; details: MultiEditDetails }> {
-    const { path, edits } = params;
+    const { edits } = params;
+    const rawPath = params.path;
+    const path = normalizePath(rawPath);
 
     if (edits.length === 0) {
       return {
         content: [{ type: 'text', text: '编辑操作列表为空' }],
-        details: { path, totalReplacements: 0, editCount: 0 }
+        details: { path: rawPath, totalReplacements: 0, editCount: 0 }
       };
     }
 
@@ -79,7 +82,7 @@ export const multiEditTool = {
               type: 'text',
               text: `编辑 #${i + 1} 失败: 未找到要替换的文本 "${old_string.substring(0, 50)}..."，已恢复原始文件内容。`
             }],
-            details: { path, totalReplacements: 0, editCount: i }
+            details: { path: rawPath, totalReplacements: 0, editCount: i }
           };
         }
 
@@ -94,7 +97,7 @@ export const multiEditTool = {
                 type: 'text',
                 text: `编辑 #${i + 1} 失败: 找到 ${matches} 处匹配，old_string 必须唯一匹配。已恢复原始文件内容。`
               }],
-              details: { path, totalReplacements: 0, editCount: i }
+              details: { path: rawPath, totalReplacements: 0, editCount: i }
             };
           }
         }
@@ -122,7 +125,7 @@ export const multiEditTool = {
           text: `批量编辑完成:\n${results.join('\n')}\n共替换 ${totalReplacements} 处`
         }],
         details: {
-          path,
+          path: rawPath,
           totalReplacements,
           editCount: edits.length
         }
@@ -131,7 +134,7 @@ export const multiEditTool = {
       const errorMsg = err instanceof Error ? err.message : String(err);
       return {
         content: [{ type: 'text', text: `批量编辑失败: ${errorMsg}` }],
-        details: { path, totalReplacements: 0, editCount: 0 }
+        details: { path: rawPath, totalReplacements: 0, editCount: 0 }
       };
     }
   }

--- a/src/tools/read-file.ts
+++ b/src/tools/read-file.ts
@@ -4,6 +4,7 @@
  */
 import { readFileSync, existsSync } from 'fs';
 import { Type, type Static } from '@sinclair/typebox';
+import { normalizePath } from '../utils/path.js';
 
 /**
  * 工具参数 schema
@@ -38,13 +39,14 @@ export const readFileTool = {
     params: ReadFileParams,
     _signal?: AbortSignal
   ): Promise<{ content: Array<{ type: 'text'; text: string }>; details: ReadFileDetails }> {
-    const { path } = params;
+    const rawPath = params.path;
+    const path = normalizePath(rawPath);
 
     // 检查文件是否存在
     if (!existsSync(path)) {
       return {
-        content: [{ type: 'text', text: `文件不存在: ${path}` }],
-        details: { path }
+        content: [{ type: 'text', text: `文件不存在: ${rawPath}` }],
+        details: { path: rawPath }
       };
     }
 
@@ -53,13 +55,13 @@ export const readFileTool = {
       const fileContent = readFileSync(path, 'utf-8');
       return {
         content: [{ type: 'text', text: fileContent }],
-        details: { path }
+        details: { path: rawPath }
       };
     } catch (err) {
       const errorMsg = err instanceof Error ? err.message : String(err);
       return {
         content: [{ type: 'text', text: `读取文件失败: ${errorMsg}` }],
-        details: { path }
+        details: { path: rawPath }
       };
     }
   }

--- a/src/tools/write-file.ts
+++ b/src/tools/write-file.ts
@@ -5,6 +5,7 @@
 import { writeFileSync, appendFileSync, existsSync, mkdirSync } from 'fs';
 import { dirname } from 'path';
 import { Type, type Static } from '@sinclair/typebox';
+import { normalizePath } from '../utils/path.js';
 
 /**
  * 工具参数 schema
@@ -47,7 +48,9 @@ export const writeFileTool = {
     params: WriteFileParams,
     _signal?: AbortSignal
   ): Promise<{ content: Array<{ type: 'text'; text: string }>; details: WriteFileDetails }> {
-    const { path, content, mode = 'overwrite' } = params;
+    const { content, mode = 'overwrite' } = params;
+    const rawPath = params.path;
+    const path = normalizePath(rawPath);
 
     try {
       // 确保目录存在
@@ -62,8 +65,8 @@ export const writeFileTool = {
           // 覆盖写入（默认模式）
           writeFileSync(path, content, 'utf-8');
           return {
-            content: [{ type: 'text', text: `文件已覆盖写入: ${path} (${content.length} 字符)` }],
-            details: { path, mode, created: !fileExists }
+            content: [{ type: 'text', text: `文件已覆盖写入: ${rawPath} (${content.length} 字符)` }],
+            details: { path: rawPath, mode, created: !fileExists }
           };
 
         case 'append':
@@ -71,15 +74,15 @@ export const writeFileTool = {
           if (fileExists) {
             appendFileSync(path, content, 'utf-8');
             return {
-              content: [{ type: 'text', text: `内容已追加到文件: ${path}` }],
-              details: { path, mode, created: false }
+              content: [{ type: 'text', text: `内容已追加到文件: ${rawPath}` }],
+              details: { path: rawPath, mode, created: false }
             };
           } else {
             // 文件不存在，创建新文件
             writeFileSync(path, content, 'utf-8');
             return {
-              content: [{ type: 'text', text: `文件已创建并写入: ${path}` }],
-              details: { path, mode, created: true }
+              content: [{ type: 'text', text: `文件已创建并写入: ${rawPath}` }],
+              details: { path: rawPath, mode, created: true }
             };
           }
 
@@ -87,14 +90,14 @@ export const writeFileTool = {
           // 仅创建新文件
           if (fileExists) {
             return {
-              content: [{ type: 'text', text: `文件已存在，未覆盖: ${path}` }],
-              details: { path, mode, created: false }
+              content: [{ type: 'text', text: `文件已存在，未覆盖: ${rawPath}` }],
+              details: { path: rawPath, mode, created: false }
             };
           } else {
             writeFileSync(path, content, 'utf-8');
             return {
-              content: [{ type: 'text', text: `文件已创建: ${path}` }],
-              details: { path, mode, created: true }
+              content: [{ type: 'text', text: `文件已创建: ${rawPath}` }],
+              details: { path: rawPath, mode, created: true }
             };
           }
       }
@@ -102,7 +105,7 @@ export const writeFileTool = {
       const errorMsg = err instanceof Error ? err.message : String(err);
       return {
         content: [{ type: 'text', text: `写入文件失败: ${errorMsg}` }],
-        details: { path, mode, created: false }
+        details: { path: rawPath, mode, created: false }
       };
     }
   }

--- a/src/utils/path.ts
+++ b/src/utils/path.ts
@@ -1,0 +1,32 @@
+/**
+ * 路径工具函数
+ * 处理跨平台路径兼容问题
+ */
+
+/**
+ * 规范化路径，处理 Git Bash / WSL 风格的 Unix 路径
+ *
+ * Windows 上 Git Bash 返回的路径格式: /c/Users/xxx
+ * 需要转换为 Windows 格式: C:\Users\xxx
+ *
+ * Linux/macOS 不受影响，路径原样返回
+ *
+ * @param p - 原始路径字符串
+ * @returns 规范化后的路径
+ */
+export function normalizePath(p: string): string {
+  // 仅在 Windows 上启用转换
+  if (process.platform !== 'win32') {
+    return p;
+  }
+
+  // 匹配 Git Bash 风格路径: /X/...  (X 是单字母盘符，紧跟斜杠)
+  // Linux /home 不匹配，因为 /h 后是 'ome' 而非 '/'
+  const match = p.match(/^\/([a-zA-Z])\/(.*)$/);
+  if (match) {
+    const rest = match[2].replace(/\//g, '\\');
+    return `${match[1].toUpperCase()}:\\${rest}`;
+  }
+
+  return p;
+}

--- a/tests/unit/utils/path.test.ts
+++ b/tests/unit/utils/path.test.ts
@@ -1,0 +1,85 @@
+/**
+ * Path normalization utility tests
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('normalizePath', () => {
+  let normalizePath: (p: string) => string;
+
+  beforeEach(async () => {
+    const mod = await import('../../../src/utils/path.js');
+    normalizePath = mod.normalizePath;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('should pass through Linux paths unchanged', () => {
+    // Simulate non-Windows platform
+    vi.stubGlobal('process', { ...process, platform: 'linux' });
+
+    expect(normalizePath('/home/user/project')).toBe('/home/user/project');
+    expect(normalizePath('/var/log/syslog')).toBe('/var/log/syslog');
+    expect(normalizePath('/tmp/test.txt')).toBe('/tmp/test.txt');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should pass through macOS paths unchanged', () => {
+    vi.stubGlobal('process', { ...process, platform: 'darwin' });
+
+    expect(normalizePath('/Users/john/Documents')).toBe('/Users/john/Documents');
+    expect(normalizePath('/Applications/ClashX Pro.app')).toBe('/Applications/ClashX Pro.app');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should convert Git Bash paths to Windows format on Windows', () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+
+    expect(normalizePath('/c/Users/test')).toBe('C:\\Users\\test');
+    expect(normalizePath('/d/Projects/miniclaw')).toBe('D:\\Projects\\miniclaw');
+    expect(normalizePath('/c/Users/Admin/Desktop/file.txt')).toBe('C:\\Users\\Admin\\Desktop\\file.txt');
+    expect(normalizePath('/e/work/docs/readme.md')).toBe('E:\\work\\docs\\readme.md');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should pass through Windows paths unchanged on Windows', () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+
+    expect(normalizePath('C:\\Users\\test')).toBe('C:\\Users\\test');
+    expect(normalizePath('D:\\Projects\\src')).toBe('D:\\Projects\\src');
+    expect(normalizePath('relative\\path')).toBe('relative\\path');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should handle edge cases on Windows', () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+
+    // Empty string
+    expect(normalizePath('')).toBe('');
+
+    // Root only
+    expect(normalizePath('/c/')).toBe('C:\\');
+
+    // Not a Git Bash path (multi-letter prefix)
+    expect(normalizePath('/home/user')).toBe('/home/user');
+
+    // UNC paths
+    expect(normalizePath('\\\\server\\share')).toBe('\\\\server\\share');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('should handle lowercase drive letters', () => {
+    vi.stubGlobal('process', { ...process, platform: 'win32' });
+
+    expect(normalizePath('/d/projects/src')).toBe('D:\\projects\\src');
+    expect(normalizePath('/a/data/file.csv')).toBe('A:\\data\\file.csv');
+
+    vi.unstubAllGlobals();
+  });
+});


### PR DESCRIPTION
## Summary
修复 Windows 上 Git Bash 路径解析问题（issue #58）

## Problem
用户在 Windows Git Bash 环境下使用 miniclaw 时，AI 工具执行 `pwd` 返回 Git Bash 风格路径 `/c/Users/...`，但 ls 等文件工具要求绝对路径，AI 错误转换为 `C:\c\Users\...` 导致文件操作失败。

## Root Cause
Git Bash 使用 `/X/` 前缀表示 Windows 盘符（如 `/c/Users` 等价于 `C:\Users`），但 AI 模型不理解这个映射关系。

## Solution
- **新增** `src/utils/path.ts`: `normalizePath()` 工具函数
  - 仅在 Windows 上启用转换
  - Git Bash 路径 `/c/Users/xxx` → `C:\Users\xxx`
  - Linux/macOS 路径原样通过（正则只匹配 `/X/` 格式）
  
- **更新 7 个文件工具**: `ls`, `read_file`, `write_file`, `edit`, `multi_edit`, `glob`, `grep`

- **新增 6 个单元测试**，覆盖 Linux、macOS、Windows 三种平台

## Test
- ✅ TypeScript 编译通过
- ✅ 全量 878 测试通过
- ✅ 6 个新路径工具测试通过

Closes #58